### PR TITLE
Fix for bug making SSB4 music unopenable

### DIFF
--- a/src/meta/ngc_dsp_std.c
+++ b/src/meta/ngc_dsp_std.c
@@ -610,7 +610,7 @@ VGMSTREAM * init_vgmstream_3ds_idsp(STREAMFILE *streamFile) {
     int channel_count;
 
     /* check extension, case insensitive */
-    //streamFile->get_name(streamFile,filename,sizeof(filename));
+    streamFile->get_name(streamFile,filename,sizeof(filename));
     //if (strcasecmp("idsp",filename_extension(filename))) goto fail;
 
     /* check header magic */


### PR DESCRIPTION
At some point, this line that gets the filename was commented out, presumably since it's not obvious that it gets on the assumption that it was only used to check the file extension. However it actually gets used later on to actually open the music file, meaning Smash music can't be converted with it commented out.