### PR TITLE
Ensure that Ogg Vorbis output is in host endian

### DIFF
--- a/src/coding/ogg_vorbis_decoder.c
+++ b/src/coding/ogg_vorbis_decoder.c
@@ -17,6 +17,8 @@ void decode_ogg_vorbis(ogg_vorbis_codec_data * data, sample * outbuf, int32_t sa
         if (rc > 0) samples_done += rc/sizeof(sample)/channels;
         else return;
     } while (samples_done < samples_to_do);
+
+    swap_samples_le(outbuf, samples_to_do*channels);
 }
 
 #endif


### PR DESCRIPTION
The ov_read command is set to output in little endian (fourth parameter = 0), but when the sample data gets to test.exe, it expects host endian. On PowerPC machines, this was causing an already little-endian buffer to have its bytes swapped. This patch swaps them a second time (for Vorbis files only) so they end up in little endian in the output.