### PR TITLE
Build fixes: FFMPEG support in test/winamp

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,7 +24,8 @@ CODING_OBJS=coding/adx_decoder.o \
     coding/mtaf_decoder.o \
     coding/at3_decoder.o \
     coding/g719_decoder.o \
-    coding/hca_decoder.o
+    coding/hca_decoder.o \
+    coding/ffmpeg_decoder.o
 
 LAYOUT_OBJS=layout/ast_blocked.o \
     layout/blocked.o \
@@ -303,7 +304,8 @@ META_OBJS=meta/adx_header.o \
 	meta/mca.o \
 	meta/btsnd.o \
 	meta/hca.o \
-	meta/ps2_svag_snk.o
+	meta/ps2_svag_snk.o \
+	meta/ffmpeg.o
 
 EXT_LIBS = ../ext_libs/clHCA.o
 

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -135,4 +135,6 @@ void decode_lsf(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, 
 
 void decode_mtaf(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel, int channels);
 
+void decode_hca(hca_codec_data * data, sample * outbuf, int32_t samples_to_do, int channels);
+
 #endif

--- a/src/meta/riff.c
+++ b/src/meta/riff.c
@@ -173,15 +173,17 @@ int read_fmt(int big_endian,
             fmt->interleave = 8;
             break;
 #ifdef VGM_USE_FFMPEG
-		case 0x270:
-		case 0xFFFE:
+		case 0x270: /* ATRAC3 */
+#if defined(VGM_USE_FFMPEG) && !defined(VGM_USE_MAIATRAC3PLUS)
+        case 0xFFFE: /* WAVEFORMATEXTENSIBLE / ATRAC3plus */
+#endif /* defined */
 			fmt->coding_type = coding_FFmpeg;
 			fmt->block_size = 2048;
 			fmt->interleave = 0;
 			break;
-#endif
+#endif /* VGM_USE_FFMPEG */
 #ifdef VGM_USE_MAIATRAC3PLUS
-		case 0xFFFE: /* WAVEFORMATEXTENSIBLE */
+		case 0xFFFE: /* WAVEFORMATEXTENSIBLE / ATRAC3plus */
 			if (read_32bit(current_chunk+0x20,streamFile) == 0xE923AABF &&
 				read_16bit(current_chunk+0x24,streamFile) == (int16_t)0xCB58 &&
 				read_16bit(current_chunk+0x26,streamFile) == 0x4471 &&

--- a/test/Makefile.mingw
+++ b/test/Makefile.mingw
@@ -1,6 +1,20 @@
+# optional parts
+export ENABLE_FFMPEG=0
+ifeq ($(ENABLE_FFMPEG),1)
+export FFMPEG_CC=-DVGM_USE_FFMPEG -I../../ffmpeg-dev/include
+export FFMPEG_LD=-L../../ffmpeg-dev/lib -lavcodec -lavformat -lavutil
+endif
+
+export ENABLE_MAIATRAC3PLUS=1
+ifeq ($(ENABLE_MAIATRAC3PLUS),1) 
+export MAT3P_CC=-DVGM_USE_MAIATRAC3PLUS
+export MAT3P_LD=-lat3plusdecoder
+endif
+
+# config
 export SHELL = /bin/sh
-export CFLAGS=-Wall -O3 -DVGM_USE_G7221 -DVGM_USE_G719 -DVGM_USE_MAIATRAC3PLUS -DVAR_ARRAYS -I../ext_includes
-export LDFLAGS=-L../src -L../ext_libs -lvgmstream -lvorbis -lmpg123-0 -lg7221_decode -lg719_decode -lat3plusdecoder -lm
+export CFLAGS=-Wall -O3 -DVGM_USE_G7221 -DVGM_USE_G719 $(MAT3P_CC) -DVAR_ARRAYS -I../ext_includes $(FFMPEG_CC)
+export LDFLAGS=-L../src -L../ext_libs -lvgmstream -lvorbis -lmpg123-0 -lg7221_decode -lg719_decode $(MAT3P_LD) -lm $(FFMPEG_LD)
 #export CC=i586-mingw32msvc-gcc
 #export AR=i586-mingw32msvc-ar
 #export STRIP=i586-mingw32msvc-strip

--- a/winamp/Makefile
+++ b/winamp/Makefile
@@ -1,6 +1,20 @@
+# optional parts
+export ENABLE_FFMPEG=0
+ifeq ($(ENABLE_FFMPEG),1)
+export FFMPEG_CC=-DVGM_USE_FFMPEG -I../../ffmpeg-dev/include
+export FFMPEG_LD=-L../../ffmpeg-dev/lib -lavcodec -lavformat -lavutil
+endif
+
+export ENABLE_MAIATRAC3PLUS=1
+ifeq ($(ENABLE_MAIATRAC3PLUS),1) 
+export MAT3P_CC=-DVGM_USE_MAIATRAC3PLUS
+export MAT3P_LD=-lat3plusdecoder
+endif
+
+# config
 export SHELL = /bin/sh
-export CFLAGS=-Wall -O3 "-DVGM_USE_G7221" "-DVGM_USE_G719" "-DVGM_USE_MAIATRAC3PLUS" "-DWIN32" "-DUSE_ALLOCA" -I../ext_includes
-export LDFLAGS=-L../src -L../ext_libs -lvgmstream -lvorbis -lmpg123-0 -lg7221_decode -lg719_decode -lat3plusdecoder -lm
+export CFLAGS=-Wall -O3 -DVGM_USE_G7221 -DVGM_USE_G719 $(MAT3P_CC) -DWIN32 -DUSE_ALLOCA -I../ext_includes $(FFMPEG_CC)
+export LDFLAGS=-L../src -L../ext_libs -lvgmstream -lvorbis -lmpg123-0 -lg7221_decode -lg719_decode $(MAT3P_LD) -lm $(FFMPEG_LD)
 export CC=i586-mingw32msvc-gcc
 export AR=i586-mingw32msvc-ar
 export STRIP=i586-mingw32msvc-strip
@@ -21,7 +35,7 @@ resource.o: resource.rc resource.h
 	$(WINDRES) -o resource.o resource.rc
 
 libvgmstream.a:
-	$(MAKE) -C ../src libvgmstream.a
+	$(MAKE) -C ../src $@
 
 libvorbis.a:
 	$(MAKE) -C ../ext_libs -f Makefile.mingw $@
@@ -36,7 +50,7 @@ libg719_decode.a:
 	$(MAKE) -C ../ext_libs -f Makefile.mingw $@
 
 libat3plusdecoder.a:
-	 $(MAKE) -C ../ext_libs -f Makefile.mingw $@
+	$(MAKE) -C ../ext_libs -f Makefile.mingw $@
 
 clean:
 	rm -f in_vgmstream.dll resource.o


### PR DESCRIPTION
Optionally compile with FFMPEG enabled in test.exe/winamp.

Works with a full build (ex. https://ffmpeg.zeranoe.com/) or my trimmed build with only a few formats (I think I could upload that to ext_libs after I understand licenses and stuff).

Note that AT3/P looping is borked using FFMPEG afaik (investigating... EDIT: got it).