### PR TITLE
FFmpeg looping fix (sample discard was not working in some cases)

### DIFF
--- a/src/coding/ffmpeg_decoder.c
+++ b/src/coding/ffmpeg_decoder.c
@@ -183,18 +183,17 @@ void decode_ffmpeg(VGMSTREAM *vgmstream,
         
         /* discard packet if needed (fully or partially) */
         if (data->samplesToDiscard) {
-            int toDiscard;
+            int samplesToConsume;
             int bytesPerFrame = ((data->bitsPerSample / 8) * channels);
 
             /* discard all if there are more samples to do than the packet's samples */
-            if ( data->samplesToDiscard - (dataSize / bytesPerFrame) >=0 ) {
-                toDiscard = dataSize;
+            if (data->samplesToDiscard >= dataSize / bytesPerFrame) {
+                samplesToConsume = dataSize / bytesPerFrame;
             }
-            else{
-                toDiscard = toConsume;
+            else {
+                samplesToConsume = toConsume / bytesPerFrame;
             }
 
-            int samplesToConsume = toDiscard / bytesPerFrame;
             if (data->samplesToDiscard >= samplesToConsume) { /* full discard: skip to next */
                 data->samplesToDiscard -= samplesToConsume;
                 bytesConsumedFromDecodedFrame = dataSize;

--- a/src/coding/ffmpeg_decoder.c
+++ b/src/coding/ffmpeg_decoder.c
@@ -117,6 +117,7 @@ void decode_ffmpeg(VGMSTREAM *vgmstream,
     endOfStream = data->endOfStream;
     endOfAudio = data->endOfAudio;
 
+    /* keep reading and decoding packets until the requested number of samples (in bytes) */
     while (bytesRead < bytesToRead) {
         int planeSize;
         int planar = av_sample_fmt_is_planar(codecCtx->sample_fmt);
@@ -127,6 +128,7 @@ void decode_ffmpeg(VGMSTREAM *vgmstream,
         if (dataSize < 0)
             dataSize = 0;
         
+        /* read packet */
         while (readNextPacket && !endOfAudio) {
             if (!endOfStream) {
                 av_packet_unref(lastReadPacket);
@@ -138,7 +140,7 @@ void decode_ffmpeg(VGMSTREAM *vgmstream,
                         break;
                 }
                 if (lastReadPacket->stream_index != streamIndex)
-                    continue;
+                    continue; /* ignore non audio streams */
             }
             
             if ((errcode = avcodec_send_packet(codecCtx, endOfStream ? NULL : lastReadPacket)) < 0) {
@@ -150,6 +152,7 @@ void decode_ffmpeg(VGMSTREAM *vgmstream,
             readNextPacket = 0;
         }
         
+        /* decode packet */
         if (dataSize <= bytesConsumedFromDecodedFrame) {
             if (endOfStream && endOfAudio)
                 break;
@@ -178,21 +181,33 @@ void decode_ffmpeg(VGMSTREAM *vgmstream,
         
         toConsume = FFMIN((dataSize - bytesConsumedFromDecodedFrame), (bytesToRead - bytesRead));
         
+        /* discard packet if needed (fully or partially) */
         if (data->samplesToDiscard) {
+            int toDiscard;
             int bytesPerFrame = ((data->bitsPerSample / 8) * channels);
-            int samplesToConsume = toConsume / bytesPerFrame;
-            if (data->samplesToDiscard >= samplesToConsume) {
+
+            /* discard all if there are more samples to do than the packet's samples */
+            if ( data->samplesToDiscard - (dataSize / bytesPerFrame) >=0 ) {
+                toDiscard = dataSize;
+            }
+            else{
+                toDiscard = toConsume;
+            }
+
+            int samplesToConsume = toDiscard / bytesPerFrame;
+            if (data->samplesToDiscard >= samplesToConsume) { /* full discard: skip to next */
                 data->samplesToDiscard -= samplesToConsume;
                 bytesConsumedFromDecodedFrame = dataSize;
                 continue;
             }
-            else {
+            else { /* partial discard: copy below */
                 bytesConsumedFromDecodedFrame += data->samplesToDiscard * bytesPerFrame;
                 toConsume -= data->samplesToDiscard * bytesPerFrame;
                 data->samplesToDiscard = 0;
             }
         }
-        
+
+        /* copy packet to buffer (mux channels if needed) */
         if (!planar || channels == 1) {
             memmove(targetBuf + bytesRead, (lastDecodedFrame->data[0] + bytesConsumedFromDecodedFrame), toConsume);
         }
@@ -210,6 +225,7 @@ void decode_ffmpeg(VGMSTREAM *vgmstream,
             }
         }
         
+        /* consume */
         bytesConsumedFromDecodedFrame += toConsume;
         bytesRead += toConsume;
     }


### PR DESCRIPTION
Sample discarding was not working properly thus looping was broken. It should work now in edge cases.
(it was updating samplesToDiscard with the requested samples_to_do, rather than using the packet's samples until small enough samplesToDiscard).


Also the current seeking/looping in FFmpeg isn't always accurate, it can desync.
I added an option, for myself mainly, to use accurate-but-probably-slower looping since I didn't want to touch the default behavior, but I'm not sure it we want broken looping... (the speed hit wasn't noticeable in my system).