### PR TITLE
Decryption keyfiles

### DIFF
--- a/src/meta/adx_header.c
+++ b/src/meta/adx_header.c
@@ -496,11 +496,9 @@ static int find_key(STREAMFILE *file, uint8_t type, uint16_t *xor_start, uint16_
 
     /* try to find key in external file first */
     {
-        char filename[PATH_LIMIT];
         uint8_t keybuf[6];
 
-        file->get_name(file,filename,sizeof(filename));
-        if ( read_key_file(keybuf, 6, filename) ) {
+        if ( read_key_file(keybuf, 6, file) ) {
             *xor_start = get_16bitBE(keybuf+0);
             *xor_mult = get_16bitBE(keybuf+2);
             *xor_add = get_16bitBE(keybuf+4);

--- a/src/meta/adx_header.c
+++ b/src/meta/adx_header.c
@@ -470,9 +470,15 @@ static struct {
     /* Phantasy Star Online 2
      * guessed with degod */
     {0x07d2,0x1ec5,0x0c7f},
+
     /* Dragon Ball Z: Dokkan Battle
      * guessed with degod */
     {0x0003,0x0d19,0x043b},
+
+    /* Kisou Ryouhei Gunhound EX (2013-01-31)(Dracue)[PSP]
+     * guessed with degod */
+    {0x0005,0x0bcd,0x1add},
+
 };
 
 static const int keys_8_count = sizeof(keys_8)/sizeof(keys_8[0]);
@@ -487,6 +493,23 @@ static int find_key(STREAMFILE *file, uint8_t type, uint16_t *xor_start, uint16_
     int startoff, endoff;
     int rc = 0;
 
+
+    /* try to find key in external file first */
+    {
+        char filename[PATH_LIMIT];
+        uint8_t keybuf[6];
+
+        file->get_name(file,filename,sizeof(filename));
+        if ( read_key_file(keybuf, 6, filename) ) {
+            *xor_start = get_16bitBE(keybuf+0);
+            *xor_mult = get_16bitBE(keybuf+2);
+            *xor_add = get_16bitBE(keybuf+4);
+            return 1;
+        }
+    }
+
+
+    /* guess key from the tables above */
     startoff=read_16bitBE(2, file)+4;
     endoff=(read_32bitBE(12, file)+31)/32*18*read_8bit(7, file)+startoff;
 

--- a/src/streamfile.c
+++ b/src/streamfile.c
@@ -271,3 +271,79 @@ size_t get_streamfile_dos_line(int dst_length, char * dst, off_t offset,
 
     return i+extra_bytes;
 }
+
+
+/**
+ * open file containing decryption keys and copy to buffer
+ * tries combinations of keynames based on the original songname
+ *
+ * returns true if found and copied
+ */
+int read_key_file(uint8_t * buf, size_t bufsize, const char * songname) {
+    char keyname[PATH_LIMIT];
+    const char *path, *ext;
+    STREAMFILE * streamFileKey = NULL;
+
+    if (strlen(songname)+4 > sizeof(keyname)) goto fail;
+
+    /* try to open a keyfile using variations:
+     *  "(name.ext)key" (per song), "(.ext)key" (per folder) */
+    {
+        ext = strrchr(songname,'.');
+        if (ext!=NULL) ext = ext+1;
+
+        path = strrchr(songname,DIR_SEPARATOR);
+        if (path!=NULL) path = path+1;
+
+        /* "(name.ext)key" */
+        strcpy(keyname, songname);
+        strcat(keyname, "key");
+        streamFileKey = open_stdio_streamfile(keyname);
+        if (streamFileKey) goto found;
+
+        /* "(name.ext)KEY" */
+        /*
+        strcpy(keyname+strlen(keyname)-3,"KEY");
+        streamFileKey = open_stdio_streamfile(keyname);
+        if (streamFileKey) goto found;
+        */
+
+
+        /* "(.ext)key" */
+        if (path) {
+            strcpy(keyname, songname);
+            keyname[path-songname] = '\0';
+            strcat(keyname, ".");
+        } else {
+            strcpy(keyname, ".");
+        }
+        if (ext) strcat(keyname, ext);
+        strcat(keyname, "key");
+        streamFileKey = open_stdio_streamfile(keyname);
+        if (streamFileKey) goto found;
+
+        /* "(.ext)KEY" */
+        /*
+        strcpy(keyname+strlen(keyname)-3,"KEY");
+        streamFileKey = open_stdio_streamfile(keyname);
+        if (streamFileKey) goto found;
+        */
+
+        goto fail;
+    }
+
+found:
+    if (get_streamfile_size(streamFileKey) != bufsize) goto fail;
+
+    if (read_streamfile(buf, 0, bufsize, streamFileKey)!=bufsize) goto fail;
+
+    close_streamfile(streamFileKey);
+
+    return 1;
+
+fail:
+    if (streamFileKey) close_streamfile(streamFileKey);
+
+    return 0;
+}
+

--- a/src/streamfile.h
+++ b/src/streamfile.h
@@ -34,6 +34,14 @@
 
 #define STREAMFILE_DEFAULT_BUFFER_SIZE 0x400
 
+#ifndef DIR_SEPARATOR
+#if defined (_WIN32) || defined (WIN32)
+#define DIR_SEPARATOR '\\'
+#else
+#define DIR_SEPARATOR '/'
+#endif
+#endif
+
 typedef struct _STREAMFILE {
     size_t (*read)(struct _STREAMFILE *,uint8_t * dest, off_t offset, size_t length);
     size_t (*get_size)(struct _STREAMFILE *);
@@ -140,5 +148,8 @@ static inline STREAMFILE * open_stdio_streamfile(const char * const filename) {
 
 size_t get_streamfile_dos_line(int dst_length, char * dst, off_t offset,
                 STREAMFILE * infile, int *line_done_ptr);
+
+int read_key_file(uint8_t * buf, size_t bufsize, const char * filename);
+
 
 #endif

--- a/src/streamfile.h
+++ b/src/streamfile.h
@@ -149,7 +149,7 @@ static inline STREAMFILE * open_stdio_streamfile(const char * const filename) {
 size_t get_streamfile_dos_line(int dst_length, char * dst, off_t offset,
                 STREAMFILE * infile, int *line_done_ptr);
 
-int read_key_file(uint8_t * buf, size_t bufsize, const char * filename);
+int read_key_file(uint8_t * buf, size_t bufsize, STREAMFILE *streamFile);
 
 
 #endif


### PR DESCRIPTION
Add a way to load decryption keys from external files, currently for ADX.

Needed for some songs where vgmstream guesses the wrong key (Gunhound PSP).
Also handy to try new keys without having to recompile.

The format is "(songname.ext)key" (per song), "(.ext)key" (per folder)