### PR TITLE
FFmpeg: keep block size constant (for edge loops), don't write on EOF

### DIFF
--- a/src/coding/ffmpeg_decoder.c
+++ b/src/coding/ffmpeg_decoder.c
@@ -90,7 +90,7 @@ void decode_ffmpeg(VGMSTREAM *vgmstream,
     
     int framesReadNow;
     
-    if (data->totalFrames && data->framesRead >= data->totalFrames) {
+    if ((data->totalFrames && data->framesRead >= data->totalFrames) || data->endOfStream || data->endOfAudio) {
         memset(outbuf, 0, samples_to_do * channels * sizeof(sample));
         return;
     }

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -869,7 +869,7 @@ typedef struct {
     int bitsPerSample;
     int floatingPoint;
     int sampleRate;
-    int64_t totalFrames;
+    int64_t totalFrames; // sample count, or 0 if unknown
     int64_t framesRead;
     int bitrate;
     


### PR DESCRIPTION
Fixes a couple of crash bugs.
- Changing the block size dynamically was messing with vgmstream's own stuff (ex, loops from num_samples to sample 0 would have totalFrames-framesRead=0 when looping)
- Added a few extra checks when duration/totalFrames isn't set.


Unfortunately there is still a subtle looping bug. Somehow it drops the next decoded frame after looping (it happens even if you manually seek to 0 avformat_seek_file at the start even before decoding anything).
All I checked so far seems fine (AVIO buffer reading/seeking offset, frame reading/decoding, different formats...), not sure what else could be wrong.