### PR TITLE
Ffmpeg fixes4

### DIFF
--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -111,6 +111,9 @@ void decode_at3plus(VGMSTREAM *vgmstream,
 #ifdef VGM_USE_FFMPEG
 void decode_ffmpeg(VGMSTREAM *stream,
                    sample * outbuf, int32_t samples_to_do, int channels);
+
+void seek_ffmpeg(VGMSTREAM *vgmstream, int32_t num_sample);
+
 #endif
 
 void decode_acm(ACMStream * acm, sample * outbuf,

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -109,11 +109,11 @@ void decode_at3plus(VGMSTREAM *vgmstream,
 #endif
 
 #ifdef VGM_USE_FFMPEG
-void decode_ffmpeg(VGMSTREAM *stream,
-                   sample * outbuf, int32_t samples_to_do, int channels);
+void decode_ffmpeg(VGMSTREAM *stream, sample * outbuf, int32_t samples_to_do, int channels);
+
+void reset_ffmpeg(VGMSTREAM *vgmstream);
 
 void seek_ffmpeg(VGMSTREAM *vgmstream, int32_t num_sample);
-
 #endif
 
 void decode_acm(ACMStream * acm, sample * outbuf,

--- a/src/coding/ffmpeg_decoder.c
+++ b/src/coding/ffmpeg_decoder.c
@@ -248,6 +248,24 @@ end:
 }
 
 
+void reset_ffmpeg(VGMSTREAM *vgmstream) {
+    ffmpeg_codec_data *data = (ffmpeg_codec_data *) vgmstream->codec_data;
+
+    if (data->formatCtx) {
+        avformat_seek_file(data->formatCtx, -1, 0, 0, 0, AVSEEK_FLAG_ANY);
+    }
+    if (data->codecCtx) {
+        avcodec_flush_buffers(data->codecCtx);
+    }
+    data->readNextPacket = 1;
+    data->bytesConsumedFromDecodedFrame = INT_MAX;
+    data->framesRead = 0;
+    data->endOfStream = 0;
+    data->endOfAudio = 0;
+    data->samplesToDiscard = 0;
+}
+
+
 void seek_ffmpeg(VGMSTREAM *vgmstream, int32_t num_sample) {
     ffmpeg_codec_data *data = (ffmpeg_codec_data *) vgmstream->codec_data;
     int64_t ts;

--- a/src/coding/ffmpeg_decoder.c
+++ b/src/coding/ffmpeg_decoder.c
@@ -247,4 +247,56 @@ end:
     data->endOfAudio = endOfAudio;
 }
 
+
+void seek_ffmpeg(VGMSTREAM *vgmstream, int32_t num_sample) {
+    ffmpeg_codec_data *data = (ffmpeg_codec_data *) vgmstream->codec_data;
+    int64_t ts;
+
+#ifndef VGM_USE_FFMPEG_ACCURATE_LOOPING
+    /* Seek to loop start by timestamp (closest frame) + adjust skipping some samples */
+    /* FFmpeg seeks by ts by design (since not all containers can accurately skip to a frame). */
+    /* TODO: this seems to be off by +-1 frames in some cases */
+    ts = num_sample;
+    if (ts >= data->sampleRate * 2) {
+        data->samplesToDiscard = data->sampleRate * 2;
+        ts -= data->samplesToDiscard;
+    }
+    else {
+        data->samplesToDiscard = (int)ts;
+        ts = 0;
+    }
+
+    /* todo fix this properly */
+    if (data->totalFrames) {
+        data->framesRead = (int)ts;
+        ts = data->framesRead * (data->formatCtx->duration) / data->totalFrames;
+    } else {
+        data->samplesToDiscard = num_sample;
+        data->framesRead = 0;
+        ts = 0;
+    }
+
+    avformat_seek_file(data->formatCtx, -1, ts - 1000, ts, ts, AVSEEK_FLAG_ANY);
+    avcodec_flush_buffers(data->codecCtx);
+#endif /* ifndef VGM_USE_FFMPEG_ACCURATE_LOOPING */
+
+#ifdef VGM_USE_FFMPEG_ACCURATE_LOOPING
+    /* Start from 0 and discard samples until loop_start for accurate looping (slower but not too noticeable) */
+    /* We could also seek by offset (AVSEEK_FLAG_BYTE) to the frame closest to the loop then discard
+     *  some samples, which is fast but would need calculations per format / when frame size is not constant */
+    data->samplesToDiscard = num_sample;
+    data->framesRead = 0;
+    ts = 0;
+
+    avformat_seek_file(data->formatCtx, -1, ts, ts, ts, AVSEEK_FLAG_ANY);
+    avcodec_flush_buffers(data->codecCtx);
+#endif /* ifdef VGM_USE_FFMPEG_ACCURATE_LOOPING */
+
+    data->readNextPacket = 1;
+    data->bytesConsumedFromDecodedFrame = INT_MAX;
+    data->endOfStream = 0;
+    data->endOfAudio = 0;
+
+}
+
 #endif

--- a/src/meta/ffmpeg.c
+++ b/src/meta/ffmpeg.c
@@ -332,7 +332,6 @@ ffmpeg_codec_data * init_ffmpeg_faux_riff(STREAMFILE *streamFile, int64_t fmt_of
     }
 
     data->bitrate = (int)(data->codecCtx->bit_rate);
-    data->framesRead = 0;
     data->endOfStream = 0;
     data->endOfAudio = 0;
 

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -1789,53 +1789,7 @@ int vgmstream_do_loop(VGMSTREAM * vgmstream) {
             }
 #ifdef VGM_USE_FFMPEG
             if (vgmstream->coding_type==coding_FFmpeg) {
-                ffmpeg_codec_data *data = (ffmpeg_codec_data *)(vgmstream->codec_data);
-                int64_t ts;
-
-#ifndef VGM_USE_FFMPEG_ACCURATE_LOOPING
-                /* Seek to loop start by timestamp (closest frame) + adjust skipping some samples */
-                /* FFmpeg seeks by ts by design (since not all containers can accurately skip to a frame). */
-                /* TODO: this seems to be off by +-1 frames in some cases */
-                ts = vgmstream->loop_start_sample;
-                if (ts >= data->sampleRate * 2) {
-                    data->samplesToDiscard = data->sampleRate * 2;
-                    ts -= data->samplesToDiscard;
-                }
-                else {
-                    data->samplesToDiscard = (int)ts;
-                    ts = 0;
-                }
-
-                /* todo fix this properly */
-                if (data->totalFrames) {
-                    data->framesRead = (int)ts;
-                    ts = data->framesRead * (data->formatCtx->duration) / data->totalFrames;
-                } else {
-                    data->samplesToDiscard = vgmstream->loop_start_sample;
-                    data->framesRead = 0;
-                    ts = 0;
-                }
-
-                avformat_seek_file(data->formatCtx, -1, ts - 1000, ts, ts, AVSEEK_FLAG_ANY);
-                avcodec_flush_buffers(data->codecCtx);
-#endif /* ifndef VGM_USE_FFMPEG_ACCURATE_LOOPING */
-
-#ifdef VGM_USE_FFMPEG_ACCURATE_LOOPING
-                /* Start from 0 and discard samples until loop_start for accurate looping (slower but not too noticeable) */
-                /* We could also seek by offset (AVSEEK_FLAG_BYTE) to the frame closest to the loop then discard
-                 *  some samples, which is fast but would need calculations per format / when frame size is not constant */
-                data->samplesToDiscard = vgmstream->loop_start_sample;
-                data->framesRead = 0;
-                ts = 0;
-
-                avformat_seek_file(data->formatCtx, -1, ts, ts, ts, AVSEEK_FLAG_ANY);
-                avcodec_flush_buffers(data->codecCtx);
-#endif /* ifdef VGM_USE_FFMPEG_ACCURATE_LOOPING */
-
-                data->readNextPacket = 1;
-                data->bytesConsumedFromDecodedFrame = INT_MAX;
-                data->endOfStream = 0;
-                data->endOfAudio = 0;
+                seek_ffmpeg(vgmstream, vgmstream->loop_start_sample);
             }
 #endif /* VGM_USE_FFMPEG */
 #if defined(VGM_USE_MP4V2) && defined(VGM_USE_FDKAAC)

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -515,20 +515,7 @@ void reset_vgmstream(VGMSTREAM * vgmstream) {
     
 #ifdef VGM_USE_FFMPEG
     if (vgmstream->coding_type==coding_FFmpeg) {
-        ffmpeg_codec_data *data = (ffmpeg_codec_data *) vgmstream->codec_data;
-        
-        if (data->formatCtx) {
-            avformat_seek_file(data->formatCtx, -1, 0, 0, 0, AVSEEK_FLAG_ANY);
-        }
-        if (data->codecCtx) {
-            avcodec_flush_buffers(data->codecCtx);
-        }
-        data->readNextPacket = 1;
-        data->bytesConsumedFromDecodedFrame = INT_MAX;
-        data->framesRead = 0;
-        data->endOfStream = 0;
-        data->endOfAudio = 0;
-        data->samplesToDiscard = 0;
+        reset_ffmpeg(vgmstream);
     }
 #endif
 

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -870,7 +870,6 @@ typedef struct {
     int floatingPoint;
     int sampleRate;
     int64_t totalFrames; // sample count, or 0 if unknown
-    int64_t framesRead;
     int bitrate;
     
     // Intermediate buffer


### PR DESCRIPTION
- Fixed some formats not properly seeking to 0 and validate they can (see ffmpeg.c init_seek)
- Fixed discard in edge cases, it should always work now
- Don't check framesRead and rely on EOFs (easier to fix bad headers out there)
- Cleanups and minor fixes

With ACCURATE_LOOPING flag it seems correct now, and I hope to fix regular looping later.
Frustratingly some odd format (.shn) still won't seek at all, even with manual avio_seeks. I'll persevere though.

There are further fixes/formats/tests I want to do, if you want to wait on doing a build with FFmpeg.
I'll notify when I feel it's stable enough.
