### PR TITLE
OTNS IMA and fixes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -309,7 +309,8 @@ META_OBJS=meta/adx_header.o \
 	meta/mp4.o \
 	meta/xma.o \
     meta/ps2.o \
-    meta/x360.o
+    meta/x360.o \
+    meta/dsp_adx.o
 
 EXT_LIBS = ../ext_libs/clHCA.o
 

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -30,8 +30,11 @@ void decode_otns_ima(VGMSTREAM * vgmstream, VGMSTREAMCHANNEL * stream, sample * 
 /* ngc_dsp_decoder */
 void decode_ngc_dsp(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do);
 void decode_ngc_dsp_mem(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, uint8_t * mem);
+
 int32_t dsp_nibbles_to_samples(int32_t nibbles);
 void dsp_read_coefs_be(VGMSTREAM * vgmstream, STREAMFILE *streamFile, off_t offset, off_t spacing);
+void dsp_read_coefs_le(VGMSTREAM * vgmstream, STREAMFILE *streamFile, off_t offset, off_t spacing);
+void dsp_read_coefs(VGMSTREAM * vgmstream, STREAMFILE *streamFile, off_t offset, off_t spacing, int be);
 
 /* ngc_dtk_decoder */
 void decode_ngc_dtk(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel);

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -25,6 +25,7 @@ void decode_rad_ima(VGMSTREAM * vgmstream,VGMSTREAMCHANNEL * stream, sample * ou
 void decode_rad_ima_mono(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do);
 void decode_apple_ima4(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do);
 void decode_ms_ima(VGMSTREAM * vgmstream,VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do,int channel);
+void decode_otns_ima(VGMSTREAM * vgmstream, VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel);
 
 /* ngc_dsp_decoder */
 void decode_ngc_dsp(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do);

--- a/src/coding/ima_decoder.c
+++ b/src/coding/ima_decoder.c
@@ -1,10 +1,18 @@
 #include "../util.h"
 #include "coding.h"
 
-const int32_t ADPCMTable[89] = 
+/**
+ * IMA ADPCM algorithms (expand one nibble to one sample, based on prev sample/history and step table).
+ * Nibbles are usually grouped in blocks/chunks, with a header, containing 1 or N channels
+ *
+ * All IMAs are mostly the same with these variations:
+ * - interleave: blocks and channels are handled externally (layouts) or internally (mixed channels)
+ * - block header: none (external), normal (4 bytes of history 16b + step 16b) or others; per channel/global
+ * - expand type: ms-ima style or others; low or high nibble first
+ */
 
+static const int32_t ADPCMTable[89] =
 {
-
     7, 8, 9, 10, 11, 12, 13, 14,
     16, 17, 19, 21, 23, 25, 28, 31,
     34, 37, 41, 45, 50, 55, 60, 66,
@@ -17,47 +25,58 @@ const int32_t ADPCMTable[89] =
     7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899,
     15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794,
     32767
-
 };
 
-const int IMA_IndexTable[16] = 
-
+static const int IMA_IndexTable[16] =
 {
     -1, -1, -1, -1, 2, 4, 6, 8,
     -1, -1, -1, -1, 2, 4, 6, 8 
 };
 
+
 void decode_nds_ima(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do) {
-    int i=first_sample;
-    int32_t sample_count;
-    int32_t hist1 = stream->adpcm_history1_16;
+    int i, sample_count;
+
+    int32_t hist1 = stream->adpcm_history1_16;//todo unneeded 16?
     int step_index = stream->adpcm_step_index;
 
-    if (first_sample==0) {
-        hist1 = read_16bitLE(stream->offset,stream->streamfile);
-        step_index = read_16bitLE(stream->offset+2,stream->streamfile);
+    //external interleave
+
+    //normal header
+    if (first_sample == 0) {
+        off_t header_offset = stream->offset;
+
+        hist1 = read_16bitLE(header_offset,stream->streamfile);
+        step_index = read_16bitLE(header_offset+2,stream->streamfile);
+
+        //todo clip step_index?
     }
 
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int sample_nibble = 
-                (read_8bit(stream->offset+4+i/2,stream->streamfile) >> (i&1?4:0))&0xf;
-        int delta;
-        int step = ADPCMTable[step_index];
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
+        off_t byte_offset = stream->offset + 4 + i/2;
+        nibble_shift = (i&1?4:0); //low nibble first
+
+        //normal ima nibble expansion
+        sample_nibble = (read_8bit(byte_offset,stream->streamfile) >> nibble_shift)&0xf;
+        sample_decoded = hist1;
+        step = ADPCMTable[step_index];
         delta = step >> 3;
         if (sample_nibble & 1) delta += step >> 2;
         if (sample_nibble & 2) delta += step >> 1;
         if (sample_nibble & 4) delta += step;
         if (sample_nibble & 8)
-            outbuf[sample_count] = clamp16(hist1 - delta);
+            sample_decoded -= delta;
         else
-            outbuf[sample_count] = clamp16(hist1 + delta);
+            sample_decoded += delta;
 
+        hist1 = clamp16(sample_decoded);
         step_index += IMA_IndexTable[sample_nibble];
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
 
-        hist1 = outbuf[sample_count];
+        outbuf[sample_count] = (short)(hist1);
     }
 
     stream->adpcm_history1_16 = hist1;
@@ -65,75 +84,84 @@ void decode_nds_ima(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspaci
 }
 
 void decode_dat4_ima(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do) {
-    int i=first_sample;
-    int32_t sample_count;
-    int32_t hist1 = stream->adpcm_history1_16;
+    int i, sample_count;
+
+    int32_t hist1 = stream->adpcm_history1_16;//todo unneeded 16?
     int step_index = stream->adpcm_step_index;
 
-    if (first_sample==0) {
-        hist1 = read_16bitLE(stream->offset,stream->streamfile);
-        step_index = read_8bit(stream->offset+2,stream->streamfile);
+    //external interleave
+
+    //normal header
+    if (first_sample == 0) {
+        off_t header_offset = stream->offset;
+
+        hist1 = read_16bitLE(header_offset,stream->streamfile);
+        step_index = read_8bit(header_offset+2,stream->streamfile); //todo use 8bit in all MS IMA?
+
+        //todo clip step_index?
     }
 
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int sample_nibble = 
-                (read_8bit(stream->offset+4+i/2,stream->streamfile) >> (i&1?0:4))&0xf;
-        int delta;
-        int step = ADPCMTable[step_index];
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
+        off_t byte_offset = stream->offset + 4 + i/2;
+        nibble_shift = (i&1?0:4); //high nibble first
+
+        //normal ima nibble expansion
+        sample_nibble = (read_8bit(byte_offset,stream->streamfile) >> nibble_shift)&0xf;
+        sample_decoded = hist1;
+        step = ADPCMTable[step_index];
         delta = step >> 3;
         if (sample_nibble & 1) delta += step >> 2;
         if (sample_nibble & 2) delta += step >> 1;
         if (sample_nibble & 4) delta += step;
         if (sample_nibble & 8)
-            outbuf[sample_count] = clamp16(hist1 - delta);
+            sample_decoded -= delta;
         else
-            outbuf[sample_count] = clamp16(hist1 + delta);
+            sample_decoded += delta;
 
+        hist1 = clamp16(sample_decoded);
         step_index += IMA_IndexTable[sample_nibble];
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
 
-        hist1 = outbuf[sample_count];
+        outbuf[sample_count] = (short)(hist1);
     }
 
     stream->adpcm_history1_16 = hist1;
     stream->adpcm_step_index = step_index;
 }
 
-/* Xbox IMA is MS IMA, but I'll leave it alone for now (esp as it has > 2 channel support) */
 void decode_ms_ima(VGMSTREAM * vgmstream,VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do,int channel) {
-    int i=first_sample;
-	int sample_nibble;
-	int sample_decoded;
-    int delta;
-    int block_samples = (vgmstream->interleave_block_size - vgmstream->channels * 4) * 2 / vgmstream->channels;
+    int i, sample_count;
 
-    int32_t sample_count=0;
-    int32_t hist1=stream->adpcm_history1_32;
+    int32_t hist1 = stream->adpcm_history1_32;
     int step_index = stream->adpcm_step_index;
-	off_t offset=stream->offset;
 
+    //internal interleave (configurable size), mixed channels (4 byte per ch)
+    int block_samples = (vgmstream->interleave_block_size - 4*vgmstream->channels) * 2 / vgmstream->channels;
     first_sample = first_sample % block_samples;
 
+    //normal header (per channel)
     if (first_sample == 0) {
+        off_t header_offset = stream->offset + 4*channel;
 
-        hist1 = read_16bitLE(offset+channel*4,stream->streamfile);
-        step_index = read_16bitLE(offset+channel*4+2,stream->streamfile);
-
+        hist1 = read_16bitLE(header_offset,stream->streamfile);
+        step_index = read_8bit(header_offset+2,stream->streamfile);
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
     }
 
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int step = ADPCMTable[step_index];
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
-        offset = stream->offset + 4*vgmstream->channels + (i/8*4*vgmstream->channels) + (i%8)/2 + 4*channel;
+        off_t byte_offset = stream->offset + 4*channel + 4*vgmstream->channels + i/8*4*vgmstream->channels + (i%8)/2;
+        nibble_shift = (i&1?4:0); //low nibble first
 
-        sample_nibble = (read_8bit(offset,stream->streamfile) >> (i&1?4:0))&0xf;
-
-		sample_decoded=hist1;
-
+        //normal ima nibble expansion
+        sample_nibble = (read_8bit(byte_offset,stream->streamfile) >> nibble_shift)&0xf;
+        sample_decoded = hist1;
+        step = ADPCMTable[step_index];
         delta = step >> 3;
         if (sample_nibble & 1) delta += step >> 2;
         if (sample_nibble & 2) delta += step >> 1;
@@ -143,56 +171,51 @@ void decode_ms_ima(VGMSTREAM * vgmstream,VGMSTREAMCHANNEL * stream, sample * out
         else
             sample_decoded += delta;
 
-		hist1=clamp16(sample_decoded);
-
+        hist1 = clamp16(sample_decoded);
         step_index += IMA_IndexTable[sample_nibble];
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
-		
-        outbuf[sample_count]=(short)(hist1);
 
+        outbuf[sample_count] = (short)(hist1);
     }
 
-	// Only increment offset on complete frame
+    //internal interleave: increment offset on complete frame
     if (i == block_samples) stream->offset += vgmstream->interleave_block_size;
 
-	stream->adpcm_history1_32=hist1;
-	stream->adpcm_step_index=step_index;
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_step_index = step_index;
 }
 
-// "Radical ADPCM", essentially MS IMA
 void decode_rad_ima(VGMSTREAM * vgmstream,VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do,int channel) {
-    int i=first_sample;
-	int sample_nibble;
-	int sample_decoded;
-    int delta;
-    int block_samples = (vgmstream->interleave_block_size - vgmstream->channels * 4) * 2 / vgmstream->channels;
+    int i, sample_count;
 
-    int32_t sample_count=0;
-    int32_t hist1=stream->adpcm_history1_32;
+    int32_t hist1 = stream->adpcm_history1_32;
     int step_index = stream->adpcm_step_index;
-	off_t offset=stream->offset;
 
+    //internal interleave (configurable size), mixed channels (4 byte per ch)
+    int block_samples = (vgmstream->interleave_block_size - 4*vgmstream->channels) * 2 / vgmstream->channels;
     first_sample = first_sample % block_samples;
 
+    //inverted header (per channel)
     if (first_sample == 0) {
+        off_t header_offset = stream->offset + 4*channel;
 
-        hist1 = read_16bitLE(offset+channel*4+2,stream->streamfile);
-        step_index = read_16bitLE(offset+channel*4,stream->streamfile);
-
+        step_index = read_16bitLE(header_offset,stream->streamfile);
+        hist1 = read_16bitLE(header_offset+2,stream->streamfile);
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
     }
 
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int step = ADPCMTable[step_index];
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
-        offset = stream->offset + 4*vgmstream->channels + (i/2*vgmstream->channels) + channel;
+        off_t byte_offset = stream->offset + 4*vgmstream->channels + channel + i/2*vgmstream->channels;
+        nibble_shift = (i&1?4:0); //low nibble first
 
-        sample_nibble = (read_8bit(offset,stream->streamfile) >> (i&1?4:0))&0xf;
-
-		sample_decoded=hist1;
-
+        //normal ima nibble expansion
+        sample_nibble = (read_8bit(byte_offset,stream->streamfile) >> nibble_shift)&0xf;
+        sample_decoded = hist1;
+        step = ADPCMTable[step_index];
         delta = step >> 3;
         if (sample_nibble & 1) delta += step >> 2;
         if (sample_nibble & 2) delta += step >> 1;
@@ -202,58 +225,51 @@ void decode_rad_ima(VGMSTREAM * vgmstream,VGMSTREAMCHANNEL * stream, sample * ou
         else
             sample_decoded += delta;
 
-		hist1=clamp16(sample_decoded);
-
+        hist1 = clamp16(sample_decoded);
         step_index += IMA_IndexTable[sample_nibble];
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
-		
-        outbuf[sample_count]=(short)(hist1);
 
+        outbuf[sample_count] = (short)(hist1);
     }
 
-	// Only increment offset on complete frame
+    //internal interleave: increment offset on complete frame
     if (i == block_samples) stream->offset += vgmstream->interleave_block_size;
 
-	stream->adpcm_history1_32=hist1;
-	stream->adpcm_step_index=step_index;
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_step_index = step_index;
 }
 
-// "Radical ADPCM", mono form (for use with interleave layout)
-// I think this is exactly equivalent to mono MS APDCM, but I need a
-// channel-agnostic version to use within an interleave.
 void decode_rad_ima_mono(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do) {
-    int i=first_sample;
-	int sample_nibble;
-	int sample_decoded;
-    int delta;
-    int block_samples = 0x14 * 2;
+    int i, sample_count;
 
-    int32_t sample_count=0;
-    int32_t hist1=stream->adpcm_history1_32;
+    int32_t hist1 = stream->adpcm_history1_32;
     int step_index = stream->adpcm_step_index;
-	off_t offset=stream->offset;
 
+    //semi-external interleave?
+    int block_samples = 0x14 * 2;
     first_sample = first_sample % block_samples;
 
+    //inverted header
     if (first_sample == 0) {
+        off_t header_offset = stream->offset;
 
-        hist1 = read_16bitLE(offset+2,stream->streamfile);
-        step_index = read_16bitLE(offset,stream->streamfile);
-
+        step_index = read_16bitLE(header_offset,stream->streamfile);
+        hist1 = read_16bitLE(header_offset+2,stream->streamfile);
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
     }
 
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int step = ADPCMTable[step_index];
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
-        offset = stream->offset + 4 + (i/2);
+        off_t byte_offset = stream->offset + 4 + i/2;
+        nibble_shift = (i&1?4:0); //low nibble first
 
-        sample_nibble = (read_8bit(offset,stream->streamfile) >> (i&1?4:0))&0xf;
-
-		sample_decoded=hist1;
-
+        //normal ima nibble expansion
+        sample_nibble = (read_8bit(byte_offset,stream->streamfile) >> nibble_shift)&0xf;
+        sample_decoded = hist1;
+        step = ADPCMTable[step_index];
         delta = step >> 3;
         if (sample_nibble & 1) delta += step >> 2;
         if (sample_nibble & 2) delta += step >> 1;
@@ -263,65 +279,65 @@ void decode_rad_ima_mono(VGMSTREAMCHANNEL * stream, sample * outbuf, int channel
         else
             sample_decoded += delta;
 
-		hist1=clamp16(sample_decoded);
-
+        hist1 = clamp16(sample_decoded);
         step_index += IMA_IndexTable[sample_nibble];
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
-		
-        outbuf[sample_count]=(short)(hist1);
 
+        outbuf[sample_count] = (short)(hist1);
     }
 
-	stream->adpcm_history1_32=hist1;
-	stream->adpcm_step_index=step_index;
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_step_index = step_index;
 }
 
+/* For multichannel the internal layout is (I think) mixed stereo channels (ex. 6ch: 2ch + 2ch + 2ch)
+ * Has extra support for EA blocks, probably could be simplified */
 void decode_xbox_ima(VGMSTREAM * vgmstream,VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do,int channel) {
-    int i=first_sample;
-	int sample_nibble;
-	int sample_decoded;
-    int delta;
+    int i, sample_count;
 
-    int32_t sample_count=0;
-    int32_t hist1=stream->adpcm_history1_32;
+    int32_t hist1 = stream->adpcm_history1_32;
     int step_index = stream->adpcm_step_index;
-	off_t offset=stream->offset;
 
-	if(vgmstream->channels==1) 
-		first_sample = first_sample % 32;
-	else
-		first_sample = first_sample % (32*(vgmstream->channels&2));
+    off_t offset = stream->offset;
 
+    //internal interleave (0x20+4 size), mixed channels (4 byte per ch, mixed stereo)
+    int block_samples = (vgmstream->channels==1) ?
+            32 :
+            32*(vgmstream->channels&2);
+    first_sample = first_sample % block_samples;
+
+    //normal header (per channel)
     if (first_sample == 0) {
+        off_t header_offset;
+        if(vgmstream->layout_type==layout_ea_blocked) {
+            header_offset = stream->offset;
+        } else {
+            header_offset = stream->offset + 4*(channel%2);
+        }
 
-		if(vgmstream->layout_type==layout_ea_blocked) {
-			hist1 = read_16bitLE(offset,stream->streamfile);
-			step_index = read_16bitLE(offset+2,stream->streamfile);
-		} else {
-			hist1 = read_16bitLE(offset+(channel%2)*4,stream->streamfile);
-			step_index = read_16bitLE(offset+(channel%2)*4+2,stream->streamfile);
-		}
+        hist1 = read_16bitLE(header_offset,stream->streamfile);
+        step_index = read_16bitLE(header_offset+2,stream->streamfile);
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
     }
 
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int step = ADPCMTable[step_index];
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
-		if(vgmstream->layout_type==layout_ea_blocked) 
-			offset = stream->offset + (i/8*4+(i%8)/2+4);
-		else {
-			if(channelspacing==1)
-				offset = stream->offset + 4 + (i/8*4+(i%8)/2+4*(channel%2));
-			else
-				offset = stream->offset + 4*2 + (i/8*4*2+(i%8)/2+4*(channel%2));
-		}
+        if(vgmstream->layout_type==layout_ea_blocked)
+            offset = stream->offset + 4 + i/8*4 + (i%8)/2;
+        else {
+            offset = (channelspacing==1) ?
+                stream->offset + 4*(channel%2) + 4 + i/8*4 + (i%8)/2 :
+                stream->offset + 4*(channel%2) + 4*2 + i/8*4*2 + (i%8)/2;
+        }
+        nibble_shift = (i&1?4:0); //low nibble first
 
-        sample_nibble = (read_8bit(offset,stream->streamfile) >> (i&1?4:0))&0xf;
-
-		sample_decoded=hist1;
-
+        //normal ima nibble expansion
+        sample_nibble = (read_8bit(offset,stream->streamfile) >> nibble_shift)&0xf;
+        sample_decoded = hist1;
+        step = ADPCMTable[step_index];
         delta = step >> 3;
         if (sample_nibble & 1) delta += step >> 2;
         if (sample_nibble & 2) delta += step >> 1;
@@ -331,66 +347,66 @@ void decode_xbox_ima(VGMSTREAM * vgmstream,VGMSTREAMCHANNEL * stream, sample * o
         else
             sample_decoded += delta;
 
-		hist1=clamp16(sample_decoded);
-
+        hist1 = clamp16(sample_decoded);
         step_index += IMA_IndexTable[sample_nibble];
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
-		
-        outbuf[sample_count]=(short)(hist1);
+
+        outbuf[sample_count] = (short)(hist1);
     }
 
-	// Only increment offset on complete frame
-	if(vgmstream->layout_type==layout_ea_blocked) {
-		if(offset-stream->offset==32+3) // ??
-			stream->offset+=36;
-	} else {
-		if(channelspacing==1) {
-			if(offset-stream->offset==32+3) // ??
-				stream->offset+=36;
-		} else {
-			if(offset-stream->offset==64+(4*(channel%2))+3) // ??
-				stream->offset+=36*channelspacing;
-		}
-	}
-	stream->adpcm_history1_32=hist1;
-	stream->adpcm_step_index=step_index;
+    //internal interleave: increment offset on complete frame
+    if(vgmstream->layout_type==layout_ea_blocked) {
+        if(offset-stream->offset==32+3) // ??
+            stream->offset+=36;
+    } else {
+        if(channelspacing==1) {
+            if(offset-stream->offset==32+3) // ??
+                stream->offset+=36;
+        } else {
+            if(offset-stream->offset==64+(4*(channel%2))+3) // ??
+                stream->offset+=36*channelspacing;
+        }
+    }
+
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_step_index = step_index;
 }
 
 void decode_int_xbox_ima(VGMSTREAM * vgmstream,VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do,int channel) {
-    int i=first_sample;
-	int sample_nibble;
-	int sample_decoded;
-    int delta;
+    int i, sample_count;
 
-    int32_t sample_count=0;
-    int32_t hist1=stream->adpcm_history1_32;
+    int32_t hist1 = stream->adpcm_history1_32;
     int step_index = stream->adpcm_step_index;
-	off_t offset=stream->offset;
 
-	if(vgmstream->channels==1) 
-		first_sample = first_sample % 32;
-	else
-		first_sample = first_sample % (32*(vgmstream->channels&2));
+    off_t offset = stream->offset;
 
+    //semi-internal interleave (0x24 size), mixed channels (4 byte per ch)?
+    int block_samples = (vgmstream->channels==1) ?
+            32 :
+            32*(vgmstream->channels&2);
+    first_sample = first_sample % block_samples;
+
+    //normal header
     if (first_sample == 0) {
+        off_t header_offset = stream->offset;
 
-		hist1 = read_16bitLE(offset,stream->streamfile);
-		step_index = read_16bitLE(offset+2,stream->streamfile);
-		
+        hist1 = read_16bitLE(header_offset,stream->streamfile);
+        step_index = read_16bitLE(header_offset+2,stream->streamfile);
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
     }
 
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int step = ADPCMTable[step_index];
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
-		offset = stream->offset + 4 + (i/8*4+(i%8)/2);
+        offset = stream->offset + 4 + i/8*4 + (i%8)/2;
+        nibble_shift = (i&1?4:0); //low nibble first
 
-        sample_nibble = (read_8bit(offset,stream->streamfile) >> (i&1?4:0))&0xf;
-
-		sample_decoded=hist1;
-
+        //normal ima nibble expansion
+        sample_nibble = (read_8bit(offset,stream->streamfile) >> nibble_shift)&0xf;
+        sample_decoded = hist1;
+        step = ADPCMTable[step_index];
         delta = step >> 3;
         if (sample_nibble & 1) delta += step >> 2;
         if (sample_nibble & 2) delta += step >> 1;
@@ -400,46 +416,47 @@ void decode_int_xbox_ima(VGMSTREAM * vgmstream,VGMSTREAMCHANNEL * stream, sample
         else
             sample_decoded += delta;
 
-		hist1=clamp16(sample_decoded);
-
+        hist1 = clamp16(sample_decoded);
         step_index += IMA_IndexTable[sample_nibble];
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
-		
-        outbuf[sample_count]=(short)(hist1);
+
+        outbuf[sample_count] = (short)(hist1);
     }
 
-	// Only increment offset on complete frame
-	if(channelspacing==1) {
-		if(offset-stream->offset==32+3) // ??
-			stream->offset+=36;
-	} else {
-		if(offset-stream->offset==64+(4*(channel%2))+3) // ??
-			stream->offset+=36*channelspacing;
-	}
-	stream->adpcm_history1_32=hist1;
-	stream->adpcm_step_index=step_index;
+    //internal interleave: increment offset on complete frame
+    if(channelspacing==1) {
+        if(offset-stream->offset==32+3) // ??
+            stream->offset+=36;
+    } else {
+        if(offset-stream->offset==64+(4*(channel%2))+3) // ??
+            stream->offset+=36*channelspacing;
+    }
+
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_step_index = step_index;
 }
 
 void decode_dvi_ima(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do) {
-    int i;
+    int i, sample_count;
 
-    int32_t sample_count=0;
-    int32_t hist1=stream->adpcm_history1_32;
+    int32_t hist1 = stream->adpcm_history1_32;
     int step_index = stream->adpcm_step_index;
 
+    //external interleave
+
+    //no header
+
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int step = ADPCMTable[step_index];
-        uint8_t sample_byte;
-        int sample_nibble;
-        int sample_decoded;
-        int delta;
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
-        sample_byte = read_8bit(stream->offset+i/2,stream->streamfile);
-        /* old-style DVI takes high nibble first */
-        sample_nibble = (sample_byte >> (i&1?0:4))&0xf;
+        off_t byte_offset = stream->offset + i/2;
+        nibble_shift = (i&1?0:4); //high nibble first (old-style DVI)
 
+        //normal ima nibble expansion
+        sample_nibble = (read_8bit(byte_offset,stream->streamfile) >> nibble_shift)&0xf;
         sample_decoded = hist1;
+        step = ADPCMTable[step_index];
         delta = step >> 3;
         if (sample_nibble & 1) delta += step >> 2;
         if (sample_nibble & 2) delta += step >> 1;
@@ -449,44 +466,44 @@ void decode_dvi_ima(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspaci
         else
             sample_decoded += delta;
 
-        hist1=clamp16(sample_decoded);
-
-        step_index += IMA_IndexTable[sample_nibble&0x7];
+        hist1 = clamp16(sample_decoded);
+        step_index += IMA_IndexTable[sample_nibble&0x7]; //todo unneeded &0x7?
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
 
-        outbuf[sample_count]=(short)(hist1);
+        outbuf[sample_count] = (short)(hist1);
     }
 
-    stream->adpcm_history1_32=hist1;
-    stream->adpcm_step_index=step_index;
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_step_index = step_index;
 }
 
-
 void decode_eacs_ima(VGMSTREAM * vgmstream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel) {
-    int i;
-    VGMSTREAMCHANNEL * stream = &(vgmstream->ch[channel]);
+    VGMSTREAMCHANNEL * stream = &(vgmstream->ch[channel]);//todo pass externally for consistency
+    int i, sample_count;
 
-    int32_t sample_count=0;
-    int32_t hist1=stream->adpcm_history1_32;
+    int32_t hist1 = stream->adpcm_history1_32;
     int step_index = stream->adpcm_step_index;
 
-	vgmstream->get_high_nibble=!vgmstream->get_high_nibble;
+    //external interleave
 
-	if((first_sample) && (channelspacing==1))
-		vgmstream->get_high_nibble=!vgmstream->get_high_nibble;
+    //no header
+
+    //variable nibble order
+    vgmstream->get_high_nibble = !vgmstream->get_high_nibble;
+    if((first_sample) && (channelspacing==1))
+        vgmstream->get_high_nibble = !vgmstream->get_high_nibble;
 
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int step = ADPCMTable[step_index];
-        uint8_t sample_byte;
-        int sample_nibble;
-        int sample_decoded;
-        int delta;
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
-        sample_byte = read_8bit(stream->offset+i,stream->streamfile);
-        sample_nibble = (sample_byte >> (vgmstream->get_high_nibble?0:4))&0xf;
+        off_t byte_offset = stream->offset + i;
+        nibble_shift = (vgmstream->get_high_nibble?0:4); //variable nibble order
 
+        //normal ima nibble expansion
+        sample_nibble = (read_8bit(byte_offset,stream->streamfile) >> nibble_shift)&0xf;
         sample_decoded = hist1;
+        step = ADPCMTable[step_index];
         delta = step >> 3;
         if (sample_nibble & 1) delta += step >> 2;
         if (sample_nibble & 2) delta += step >> 1;
@@ -496,85 +513,86 @@ void decode_eacs_ima(VGMSTREAM * vgmstream, sample * outbuf, int channelspacing,
         else
             sample_decoded += delta;
 
-        hist1=clamp16(sample_decoded);
-
-        step_index += IMA_IndexTable[sample_nibble&0x7];
+        hist1 = clamp16(sample_decoded);
+        step_index += IMA_IndexTable[sample_nibble&0x7]; //todo unneeded &0x7?
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
 
-        outbuf[sample_count]=(short)(hist1);
+        outbuf[sample_count] = (short)(hist1);
     }
 
-    stream->adpcm_history1_32=hist1;
-    stream->adpcm_step_index=step_index;
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_step_index = step_index;
 }
 
 void decode_ima(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do) {
-	int i;
+    int i, sample_count;
 
-	int32_t sample_count = 0;
-	int32_t hist1 = stream->adpcm_history1_32;
-	int step_index = stream->adpcm_step_index;
+    int32_t hist1 = stream->adpcm_history1_32;
+    int step_index = stream->adpcm_step_index;
 
-	for (i = first_sample, sample_count = 0; i<first_sample + samples_to_do; i++, sample_count += channelspacing) {
-		int step = ADPCMTable[step_index];
-		uint8_t sample_byte;
-		int sample_nibble;
-		int sample_decoded;
-		int delta;
+    //external interleave
 
-		sample_byte = read_8bit(stream->offset + i / 2, stream->streamfile);
-		sample_nibble = (sample_byte >> (i & 1 ? 4 : 0)) & 0xf;
+    //no header
 
-		sample_decoded = hist1 << 3;
+    for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
-		delta = step * (sample_nibble & 7) * 2 + step;
-		if (sample_nibble & 8)
-			sample_decoded -= delta;
-		else
-			sample_decoded += delta;
+        off_t byte_offset = stream->offset + i/2;
+        nibble_shift = (i&1?4:0); //low nibble order
 
-		hist1 = clamp16(sample_decoded >> 3);
+        //"original" ima nibble expansion
+        sample_nibble = (read_8bit(byte_offset,stream->streamfile) >> nibble_shift)&0xf;
+        sample_decoded = hist1 << 3;
+        step = ADPCMTable[step_index];
+        delta = step * (sample_nibble & 7) * 2 + step;
+        if (sample_nibble & 8)
+            sample_decoded -= delta;
+        else
+            sample_decoded += delta;
 
-		step_index += IMA_IndexTable[sample_nibble & 0x7];
-		if (step_index < 0) step_index = 0;
-		if (step_index > 88) step_index = 88;
+        hist1 = clamp16(sample_decoded >> 3);
+        step_index += IMA_IndexTable[sample_nibble&0x7]; //todo unneeded &0x7?
+        if (step_index < 0) step_index=0;
+        if (step_index > 88) step_index=88;
 
-		outbuf[sample_count] = (short)(hist1);
-	}
+        outbuf[sample_count] = (short)(hist1);
+    }
 
-	stream->adpcm_history1_32 = hist1;
-	stream->adpcm_step_index = step_index;
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_step_index = step_index;
 }
 
 void decode_apple_ima4(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do) {
-    int i;
+    int i, sample_count;
 
-    int32_t sample_count=0;
-    int16_t hist1=stream->adpcm_history1_16;
+    int16_t hist1 = stream->adpcm_history1_16;//todo unneeded 16?
     int step_index = stream->adpcm_step_index;
 
     off_t packet_offset = stream->offset + first_sample/64*34;
 
-    first_sample  = first_sample % 64;
+    //semi-internal interleave //todo what
+    int block_samples = 64;
+    first_sample = first_sample % block_samples;
 
-    if (first_sample == 0)
-    {
+    //2-byte header
+    if (first_sample == 0) {
         hist1 = (int16_t)((uint16_t)read_16bitBE(packet_offset,stream->streamfile) & 0xff80);
         step_index = read_8bit(packet_offset+1,stream->streamfile) & 0x7f;
+
+        //todo no clamp
     }
 
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int step = ADPCMTable[step_index];
-        uint8_t sample_byte;
-        int sample_nibble;
-        int sample_decoded;
-        int delta;
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
-        sample_byte = read_8bit(packet_offset+2+i/2,stream->streamfile);
-        sample_nibble = (sample_byte >> (i&1?4:0))&0xf;
+        off_t byte_offset = packet_offset + 2 + i/2;
+        nibble_shift = (i&1?4:0); //low nibble first
 
+        //normal ima nibble expansion
+        sample_nibble = (read_8bit(byte_offset,stream->streamfile) >> nibble_shift)&0xf;
         sample_decoded = hist1;
+        step = ADPCMTable[step_index];
         delta = step >> 3;
         if (sample_nibble & 1) delta += step >> 2;
         if (sample_nibble & 2) delta += step >> 1;
@@ -584,52 +602,51 @@ void decode_apple_ima4(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelsp
         else
             sample_decoded += delta;
 
-        hist1=clamp16(sample_decoded);
-
-        step_index += IMA_IndexTable[sample_nibble&0x7];
+        hist1 = clamp16(sample_decoded);
+        step_index += IMA_IndexTable[sample_nibble&0x7]; //todo unneeded &0x7?
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
 
-        outbuf[sample_count]=(short)(hist1);
+        outbuf[sample_count] = (short)(hist1);
     }
 
-    stream->adpcm_history1_16=hist1;
-    stream->adpcm_step_index=step_index;
+    stream->adpcm_history1_16 = hist1;
+    stream->adpcm_step_index = step_index;
 }
 
 void decode_snds_ima(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel) {
-    int i;
+    int i, sample_count;
 
-    int32_t sample_count=0;
-    int32_t hist1=stream->adpcm_history1_32;
+    int32_t hist1 = stream->adpcm_history1_32;
     int step_index = stream->adpcm_step_index;
 
+    //external interleave
+
+    //no header
+
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int step;
-        uint8_t sample_byte;
-        int sample_nibble;
-        int sample_decoded;
-        int delta;
+        int nibble_shift, sample_nibble, sample_decoded, step, delta;
 
-        sample_byte = read_8bit(stream->offset+i,stream->streamfile);
-        sample_nibble = (sample_byte >> (channel==0?0:4))&0xf;
+        off_t byte_offset = stream->offset + i;//one nibble per channel
+        nibble_shift = (channel==0?0:4); //high nibble first, based on channel
 
-        // update step before doing current sample
+        //snds nibble expansion (update step_index before doing current sample)
+        sample_nibble = (read_8bit(byte_offset,stream->streamfile) >> nibble_shift)&0xf;
+
         step_index += IMA_IndexTable[sample_nibble];
         if (step_index < 0) step_index=0;
         if (step_index > 88) step_index=88;
-        step = ADPCMTable[step_index];
 
+        step = ADPCMTable[step_index];
         delta = (sample_nibble & 7) * step / 4 + step / 8;
         if (sample_nibble & 8) delta = -delta;
         sample_decoded = hist1 + delta;
 
-        hist1=clamp16(sample_decoded);
+        hist1 = clamp16(sample_decoded);
 
-        outbuf[sample_count]=(short)(hist1);
+        outbuf[sample_count] = (short)(hist1);
     }
 
-    stream->adpcm_history1_32=hist1;
-    stream->adpcm_step_index=step_index;
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_step_index = step_index;
 }
-

--- a/src/coding/ngc_dsp_decoder.c
+++ b/src/coding/ngc_dsp_decoder.c
@@ -100,12 +100,19 @@ int32_t dsp_nibbles_to_samples(int32_t nibbles) {
  * reads DSP coefs built in the streamfile
  */
 void dsp_read_coefs_be(VGMSTREAM * vgmstream, STREAMFILE *streamFile, off_t offset, off_t spacing) {
+    dsp_read_coefs(vgmstream, streamFile, offset, spacing, 1);
+}
+void dsp_read_coefs_le(VGMSTREAM * vgmstream, STREAMFILE *streamFile, off_t offset, off_t spacing) {
+    dsp_read_coefs(vgmstream, streamFile, offset, spacing, 0);
+}
+void dsp_read_coefs(VGMSTREAM * vgmstream, STREAMFILE *streamFile, off_t offset, off_t spacing, int be) {
     int ch, i;
     /* get ADPCM coefs */
     for (ch=0; ch < vgmstream->channels; ch++) {
         for (i=0; i < 16; i++) {
-            vgmstream->ch[ch].adpcm_coef[i] =
-                    read_16bitBE(offset + ch*spacing + i*2, streamFile);
+            vgmstream->ch[ch].adpcm_coef[i] = be ?
+                    read_16bitBE(offset + ch*spacing + i*2, streamFile) :
+                    read_16bitLE(offset + ch*spacing + i*2, streamFile);
         }
     }
 }

--- a/src/formats.c
+++ b/src/formats.c
@@ -167,7 +167,7 @@ static const char* extension_list[] = {
     "ngca",
     "nps",
     "npsf",
-    "nus3bank", //todo not existing?
+    "nus3bank",
     "nwa",
 
     "oma", //FFmpeg, not parsed (ATRAC3/ATRAC3PLUS/MP3/LPCM/WMA)
@@ -405,6 +405,7 @@ static const coding_info coding_info_list[] = {
         {coding_RAD_IMA_mono,       "'Radical' 4-bit IMA ADPCM (mono)"},
         {coding_APPLE_IMA4,         "Apple Quicktime 4-bit IMA ADPCM"},
         {coding_SNDS_IMA,           "Heavy Iron .snds 4-bit IMA ADPCM"},
+        {coding_OTNS_IMA,           "Omikron: The Nomad Soul 4-bit IMA ADPCM"},
         {coding_WS,                 "Westwood Studios ADPCM"},
         {coding_ACM,                "InterPlay ACM"},
         {coding_NWA0,               "NWA DPCM Level 0"},
@@ -787,6 +788,7 @@ static const meta_info meta_info_list[] = {
         {meta_HYPERSCAN_KVAG,       "Mattel Hyperscan KVAG"},
         {meta_IOS_PSND,             "PSND Header"},
         {meta_BOS_ADP,              "ADP! header"},
+        {meta_OTNS_ADP,             "Omikron: The Nomad Soul ADP header"},
         {meta_EB_SFX,               "Excitebots .sfx header"},
         {meta_EB_SF0,               "assumed Excitebots .sf0 by extension"},
         {meta_PS3_KLBS,             "klBS Header"},

--- a/src/libvgmstream.vcproj
+++ b/src/libvgmstream.vcproj
@@ -320,6 +320,10 @@
 					RelativePath=".\meta\dmsg_segh.c"
 					>
 				</File>
+                <File
+                    RelativePath=".\meta\dsp_adx.c"
+                    >
+                </File>
 				<File
 					RelativePath=".\meta\dsp_bdsp.c"
 					>

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="meta\dc_str.c" />
     <ClCompile Include="meta\de2.c" />
     <ClCompile Include="meta\dmsg_segh.c" />
+    <ClCompile Include="meta\dsp_adx.c" />
     <ClCompile Include="meta\dsp_bdsp.c" />
     <ClCompile Include="meta\dsp_sth_str.c" />
     <ClCompile Include="meta\ea_header.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1027,5 +1027,8 @@
     <ClCompile Include="meta\x360.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\dsp_adx.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/meta/Makefile.unix.am
+++ b/src/meta/Makefile.unix.am
@@ -250,5 +250,6 @@ libmeta_la_SOURCES += mp4.c
 libmeta_la_SOURCES += xma.c
 libmeta_la_SOURCES += ps2.c
 libmeta_la_SOURCES += x360.c
+libmeta_la_SOURCES += dsp_adx.c
 
 EXTRA_DIST = meta.h

--- a/src/meta/ads.c
+++ b/src/meta/ads.c
@@ -1,18 +1,17 @@
 #include "meta.h"
 #include "../util.h"
+#include "../coding/coding.h"
 
-/* ADS (from Gauntlet Dark Legends (GC)) */
+/* ADS - from Gauntlet Dark Legacy (GC/Xbox) */
 VGMSTREAM * init_vgmstream_ads(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
-    char filename[PATH_LIMIT];
     off_t start_offset;
     int loop_flag;
     int channel_count;
     int identifer_byte;
 
     /* check extension, case insensitive */
-    streamFile->get_name(streamFile,filename,sizeof(filename));
-    if (strcasecmp("ads",filename_extension(filename))) goto fail;
+    if (!check_extensions(streamFile,"ads")) goto fail;
 
     /* check dhSS Header */
     if (read_32bitBE(0x00,streamFile) != 0x64685353)
@@ -35,86 +34,52 @@ VGMSTREAM * init_vgmstream_ads(STREAMFILE *streamFile) {
     /* fill in the vital statistics */
     identifer_byte = read_32bitBE(0x08,streamFile);
     switch (identifer_byte) {
-        case 0x00000020:
-            start_offset = 0xE8;
+        case 0x00000020: /* GC */
+            start_offset = 0x28 + 0x60 * channel_count;
             vgmstream->channels = channel_count;
             vgmstream->sample_rate = read_32bitBE(0x0c,streamFile);
             vgmstream->coding_type = coding_NGC_DSP;
             vgmstream->num_samples = read_32bitBE(0x28,streamFile);
-        if (loop_flag) {
-            vgmstream->loop_start_sample = 0;
-            vgmstream->loop_end_sample = vgmstream->num_samples;
-        }
+            if (loop_flag) {
+                vgmstream->loop_start_sample = 0;
+                vgmstream->loop_end_sample = vgmstream->num_samples;
+            }
         
-        if (channel_count == 1){
-            vgmstream->layout_type = layout_none;
-        } else if (channel_count == 2){
-            vgmstream->layout_type = layout_interleave;
-            vgmstream->interleave_block_size = read_32bitBE(0x14,streamFile);
-        }
-    break;
-        case 0x00000021:
+            if (channel_count == 1){
+                vgmstream->layout_type = layout_none;
+            } else if (channel_count == 2){
+                vgmstream->layout_type = layout_interleave;
+                vgmstream->interleave_block_size = read_32bitBE(0x14,streamFile);
+            }
+
+            dsp_read_coefs_be(vgmstream, streamFile, 0x44,0x60);
+            break;
+
+        case 0x00000021: /* Xbox */
             start_offset = 0x28;
             vgmstream->channels = channel_count;
             vgmstream->sample_rate = read_32bitBE(0x0c,streamFile);
             vgmstream->coding_type = coding_INT_XBOX;
             vgmstream->num_samples = (read_32bitBE(0x24,streamFile) / 36 *64 / vgmstream->channels)-64; // to avoid the "pop" at the loop point
-            vgmstream->layout_type = layout_interleave;
+            vgmstream->layout_type = channel_count == 1 ? layout_none : layout_interleave;
             vgmstream->interleave_block_size = 0x24;
-        if (loop_flag) {
-            vgmstream->loop_start_sample = 0;
-            vgmstream->loop_end_sample = vgmstream->num_samples;
-        }
-        break;
-    default:
-goto fail;
-}
+            if (loop_flag) {
+                vgmstream->loop_start_sample = 0;
+                vgmstream->loop_end_sample = vgmstream->num_samples;
+            }
+            break;
+
+        default:
+            goto fail;
+    }
 
     vgmstream->meta_type = meta_ADS;
 
-        {
-        int i;
-        for (i=0;i<16;i++)
-            vgmstream->ch[0].adpcm_coef[i] = read_16bitBE(0x44+i*2,streamFile);
-        if (channel_count == 2) {
-        for (i=0;i<16;i++)
-            vgmstream->ch[1].adpcm_coef[i] = read_16bitBE(0xA4+i*2,streamFile);
-    }
-        }
-
-
-    /* open the file for reading */
-    if (vgmstream->coding_type == coding_NGC_DSP) {
-        int i,c;
-        for (c=0;c<channel_count;c++) {
-            for (i=0;i<16;i++) {
-                vgmstream->ch[c].adpcm_coef[i] =
-                    read_16bitBE(0x44+c*0x60 +i*2,streamFile);
-            }
-        }
-    }
-
-    /* open the file for reading */
-    {
-        int i;
-        STREAMFILE * file;
-        file = streamFile->open(streamFile,filename,STREAMFILE_DEFAULT_BUFFER_SIZE);
-        if (!file) goto fail;
-        for (i=0;i<channel_count;i++) {
-            vgmstream->ch[i].streamfile = file;
-
-            
-            vgmstream->ch[i].channel_start_offset=
-                start_offset+vgmstream->interleave_block_size*i;
-            vgmstream->ch[i].offset = vgmstream->ch[i].channel_start_offset;
-
-        }
-    }
-
+    if (!vgmstream_open_stream(vgmstream, streamFile, start_offset))
+        goto fail;
     return vgmstream;
 
 fail:
-    /* clean up anything we may have opened */
-    if (vgmstream) close_vgmstream(vgmstream);
+    close_vgmstream(vgmstream);
     return NULL;
 }

--- a/src/meta/adx_header.c
+++ b/src/meta/adx_header.c
@@ -16,7 +16,7 @@ VGMSTREAM * init_vgmstream_adx(STREAMFILE *streamFile) {
     off_t stream_offset;
     uint16_t version_signature;
     int loop_flag=0;
-    int channel_count, i, j, channel_header_spacing;
+    int channel_count;
     int32_t loop_start_sample=0;
     int32_t loop_end_sample=0;
     meta_t header_type;
@@ -25,207 +25,170 @@ VGMSTREAM * init_vgmstream_adx(STREAMFILE *streamFile) {
     char filename[PATH_LIMIT];
     int coding_type = coding_CRI_ADX;
     uint16_t xor_start=0,xor_mult=0,xor_add=0;
-	/* Xenoblade Chronicles 3D uses an adx extension as with
-	   the Wii version, but it's actually DSP ADPCM. Adding 
-	   this flag to account for it. */
-	int xb3d_flag = 0;
-	
+
     /* check extension, case insensitive */
     streamFile->get_name(streamFile,filename,sizeof(filename));
     if (strcasecmp("adx",filename_extension(filename))) goto fail;
 
     /* check first 2 bytes */
-    if ((uint16_t)read_16bitBE(0,streamFile)!=0x8000) {
-		if (read_8bit(0,streamFile)!=2)goto fail;
-		else {xb3d_flag = 1; coding_type = coding_NGC_DSP;}
-	}
-	
-	if (xb3d_flag) {
-		channel_count = read_32bitLE(0, streamFile);
-		loop_flag = read_16bitLE(0x6e, streamFile);
-		channel_header_spacing = 0x34;
-	}
-	else {
-		/* get stream offset, check for CRI signature just before */
-		stream_offset = (uint16_t)read_16bitBE(2,streamFile) + 4;
-		if ((uint16_t)read_16bitBE(stream_offset-6,streamFile)!=0x2863 ||/* "(c" */
-			(uint32_t)read_32bitBE(stream_offset-4,streamFile)!=0x29435249 /* ")CRI" */
-		   ) goto fail;
+    if ((uint16_t)read_16bitBE(0,streamFile)!=0x8000) goto fail;
 
-		/* check for encoding type */
-		/* 2 is for some unknown fixed filter, 3 is standard ADX, 4 is
-		 * ADX with exponential scale, 0x11 is AHX */
-		if (read_8bit(4,streamFile) != 3) goto fail;
+    /* get stream offset, check for CRI signature just before */
+    stream_offset = (uint16_t)read_16bitBE(2,streamFile) + 4;
+    if ((uint16_t)read_16bitBE(stream_offset-6,streamFile)!=0x2863 ||/* "(c" */
+        (uint32_t)read_32bitBE(stream_offset-4,streamFile)!=0x29435249 /* ")CRI" */
+       ) goto fail;
 
-		/* check for frame size (only 18 is supported at the moment) */
-		if (read_8bit(5,streamFile) != 18) goto fail;
+    /* check for encoding type */
+    /* 2 is for some unknown fixed filter, 3 is standard ADX, 4 is
+     * ADX with exponential scale, 0x11 is AHX */
+    if (read_8bit(4,streamFile) != 3) goto fail;
 
-		/* check for bits per sample? (only 4 makes sense for ADX) */
-		if (read_8bit(6,streamFile) != 4) goto fail;
+    /* check for frame size (only 18 is supported at the moment) */
+    if (read_8bit(5,streamFile) != 18) goto fail;
 
-		/* check version signature, read loop info */
-		version_signature = read_16bitBE(0x12,streamFile);
-		/* encryption */
-		if (version_signature == 0x0408) {
-			if (find_key(streamFile, 8, &xor_start, &xor_mult, &xor_add))
-			{
-				coding_type = coding_CRI_ADX_enc_8;
-				version_signature = 0x0400;
-			}
-		}
-		else if (version_signature == 0x0409) {
-			if (find_key(streamFile, 9, &xor_start, &xor_mult, &xor_add))
-			{
-				coding_type = coding_CRI_ADX_enc_9;
-				version_signature = 0x0400;
-			}
-		}
+    /* check for bits per sample? (only 4 makes sense for ADX) */
+    if (read_8bit(6,streamFile) != 4) goto fail;
 
-		if (version_signature == 0x0300) {      /* type 03 */
-			header_type = meta_ADX_03;
-			if (stream_offset-6 >= 0x2c) {   /* enough space for loop info? */
-				loop_flag = (read_32bitBE(0x18,streamFile) != 0);
-				loop_start_sample = read_32bitBE(0x1c,streamFile);
-				//loop_start_offset = read_32bitBE(0x20,streamFile);
-				loop_end_sample = read_32bitBE(0x24,streamFile);
-				//loop_end_offset = read_32bitBE(0x28,streamFile);
-			}
-		} else if (version_signature == 0x0400) {
+    /* check version signature, read loop info */
+    version_signature = read_16bitBE(0x12,streamFile);
+    /* encryption */
+    if (version_signature == 0x0408) {
+        if (find_key(streamFile, 8, &xor_start, &xor_mult, &xor_add))
+        {
+            coding_type = coding_CRI_ADX_enc_8;
+            version_signature = 0x0400;
+        }
+    }
+    else if (version_signature == 0x0409) {
+        if (find_key(streamFile, 9, &xor_start, &xor_mult, &xor_add))
+        {
+            coding_type = coding_CRI_ADX_enc_9;
+            version_signature = 0x0400;
+        }
+    }
 
-			off_t	ainf_info_length=0;
+    if (version_signature == 0x0300) {      /* type 03 */
+        header_type = meta_ADX_03;
+        if (stream_offset-6 >= 0x2c) {   /* enough space for loop info? */
+            loop_flag = (read_32bitBE(0x18,streamFile) != 0);
+            loop_start_sample = read_32bitBE(0x1c,streamFile);
+            //loop_start_offset = read_32bitBE(0x20,streamFile);
+            loop_end_sample = read_32bitBE(0x24,streamFile);
+            //loop_end_offset = read_32bitBE(0x28,streamFile);
+        }
+    } else if (version_signature == 0x0400) {
 
-			if((uint32_t)read_32bitBE(0x24,streamFile)==0x41494E46) /* AINF Header */
-				ainf_info_length = (off_t)read_32bitBE(0x28,streamFile);
+        off_t	ainf_info_length=0;
 
-			header_type = meta_ADX_04;
-			if (stream_offset-ainf_info_length-6 >= 0x38) {   /* enough space for loop info? */
-			if (read_32bitBE(0x24,streamFile) == 0xFFFEFFFE)
-				loop_flag = 0;
-			else
-				loop_flag = (read_32bitBE(0x24,streamFile) != 0);
+        if((uint32_t)read_32bitBE(0x24,streamFile)==0x41494E46) /* AINF Header */
+            ainf_info_length = (off_t)read_32bitBE(0x28,streamFile);
 
-				loop_start_sample = read_32bitBE(0x28,streamFile);
-				//loop_start_offset = read_32bitBE(0x2c,streamFile);
-				loop_end_sample = read_32bitBE(0x30,streamFile);
-				//loop_end_offset = read_32bitBE(0x34,streamFile);
-			}
+        header_type = meta_ADX_04;
+        if (stream_offset-ainf_info_length-6 >= 0x38) {   /* enough space for loop info? */
+        if (read_32bitBE(0x24,streamFile) == 0xFFFEFFFE)
+            loop_flag = 0;
+        else
+            loop_flag = (read_32bitBE(0x24,streamFile) != 0);
 
-			/* AINF header can also start after the loop points
-			 *  (may be inserted by CRI's tools but is rarely used) */
-			/* ainf_magic = read_32bitBE(0x38,streamFile); */ /* 0x41494E46 */
-            /* ainf_length = read_32bitBE(0x3c,streamFile); */
-            /* ainf_str_id = read_string(0x40,streamFile); */ /* max size 0x10 */
-            /* ainf_volume = read_16bitBE(0x50,streamFile); */ /* 0=base/max?, negative=reduce */
-            /* ainf_pan_l = read_16bitBE(0x54,streamFile); */ /* 0=base, max +-128 */
-            /* ainf_pan_r = read_16bitBE(0x56,streamFile); */
+            loop_start_sample = read_32bitBE(0x28,streamFile);
+            //loop_start_offset = read_32bitBE(0x2c,streamFile);
+            loop_end_sample = read_32bitBE(0x30,streamFile);
+            //loop_end_offset = read_32bitBE(0x34,streamFile);
+        }
 
-		} else if (version_signature == 0x0500) {			 /* found in some SFD : Buggy Heat, appears to have no loop */
-			header_type = meta_ADX_05;
-		} else goto fail;   /* not a known/supported version signature */
+        /* AINF header can also start after the loop points
+         *  (may be inserted by CRI's tools but is rarely used) */
+        /* ainf_magic = read_32bitBE(0x38,streamFile); */ /* 0x41494E46 */
+        /* ainf_length = read_32bitBE(0x3c,streamFile); */
+        /* ainf_str_id = read_string(0x40,streamFile); */ /* max size 0x10 */
+        /* ainf_volume = read_16bitBE(0x50,streamFile); */ /* 0=base/max?, negative=reduce */
+        /* ainf_pan_l = read_16bitBE(0x54,streamFile); */ /* 0=base, max +-128 */
+        /* ainf_pan_r = read_16bitBE(0x56,streamFile); */
 
-		/* At this point we almost certainly have an ADX file,
-		 * so let's build the VGMSTREAM. */
+    } else if (version_signature == 0x0500) {			 /* found in some SFD : Buggy Heat, appears to have no loop */
+        header_type = meta_ADX_05;
+    } else goto fail;   /* not a known/supported version signature */
 
-		/* high-pass cutoff frequency, always 500 that I've seen */
-		cutoff = (uint16_t)read_16bitBE(0x10,streamFile);
+    /* At this point we almost certainly have an ADX file,
+     * so let's build the VGMSTREAM. */
 
-		if (loop_start_sample == 0 && loop_end_sample == 0) {
-			loop_flag = 0;
-		}
+    /* high-pass cutoff frequency, always 500 that I've seen */
+    cutoff = (uint16_t)read_16bitBE(0x10,streamFile);
 
-		channel_count = read_8bit(7,streamFile);
-	}
+    if (loop_start_sample == 0 && loop_end_sample == 0) {
+        loop_flag = 0;
+    }
+
+    channel_count = read_8bit(7,streamFile);
     vgmstream = allocate_vgmstream(channel_count,loop_flag);
     if (!vgmstream) goto fail;
 
     /* fill in the vital statistics */
-  
-	if (xb3d_flag) {
-		for (j=0;j<vgmstream->channels;j++) {
-            for (i=0;i<16;i++) {
-                vgmstream->ch[j].adpcm_coef[i]=read_16bitLE(4+j*channel_header_spacing+i*2,streamFile);
+    vgmstream->num_samples = read_32bitBE(0xc,streamFile);
+    vgmstream->sample_rate = read_32bitBE(8,streamFile);
+    /* channels and loop flag are set by allocate_vgmstream */
+    vgmstream->loop_start_sample = loop_start_sample;
+    vgmstream->loop_end_sample = loop_end_sample;
+
+    vgmstream->coding_type = coding_type;
+    if (channel_count==1)
+        vgmstream->layout_type = layout_none;
+    else
+        vgmstream->layout_type = layout_interleave;
+    vgmstream->meta_type = header_type;
+
+    vgmstream->interleave_block_size=18;
+
+    /* calculate filter coefficients */
+    {
+        double x,y,z,a,b,c;
+
+        x = cutoff;
+        y = vgmstream->sample_rate;
+        z = cos(2.0*M_PI*x/y);
+
+        a = M_SQRT2-z;
+        b = M_SQRT2-1.0;
+        c = (a-sqrt((a+b)*(a-b)))/b;
+
+        coef1 = floor(c*8192);
+        coef2 = floor(c*c*-4096);
+    }
+
+    {
+        int i;
+        STREAMFILE * chstreamfile;
+		
+        /* ADX is so tightly interleaved that having two buffers is silly */
+        chstreamfile = streamFile->open(streamFile,filename,18*0x400);
+        if (!chstreamfile) goto fail;
+
+        for (i=0;i<channel_count;i++) {
+            vgmstream->ch[i].streamfile = chstreamfile;
+
+            vgmstream->ch[i].channel_start_offset=
+                vgmstream->ch[i].offset=
+                stream_offset+18*i;
+
+            vgmstream->ch[i].adpcm_coef[0] = coef1;
+            vgmstream->ch[i].adpcm_coef[1] = coef2;
+
+            if (coding_type == coding_CRI_ADX_enc_8 ||
+                coding_type == coding_CRI_ADX_enc_9)
+            {
+                int j;
+                vgmstream->ch[i].adx_channels = channel_count;
+                vgmstream->ch[i].adx_xor = xor_start;
+                vgmstream->ch[i].adx_mult = xor_mult;
+                vgmstream->ch[i].adx_add = xor_add;
+
+                for (j=0;j<i;j++)
+                    adx_next_key(&vgmstream->ch[i]);
             }
         }
-		vgmstream->layout_type = layout_none;
-		vgmstream->coding_type = coding_type;
-		vgmstream->meta_type = meta_XB3D_ADX;
-		vgmstream->sample_rate = read_32bitLE(0x70,streamFile);
-		vgmstream->num_samples = read_32bitLE(0x74, streamFile);
-		vgmstream->loop_start_sample = read_32bitLE(0x78, streamFile);
-		vgmstream->loop_end_sample = read_32bitLE(0x7c, streamFile);
-		
-		for (i = 0; i<channel_count; i++) {
-			vgmstream->ch[i].streamfile = streamFile->open(streamFile, filename, 0x1000);
-			vgmstream->ch[i].channel_start_offset = vgmstream->ch[i].offset
-			= read_32bitLE(0x34+i*channel_header_spacing, streamFile);
-			if (!vgmstream->ch[i].streamfile) goto fail;
-		}
-		
-	}
-	else {
-		vgmstream->num_samples = read_32bitBE(0xc,streamFile);
-		vgmstream->sample_rate = read_32bitBE(8,streamFile);
-		/* channels and loop flag are set by allocate_vgmstream */
-		vgmstream->loop_start_sample = loop_start_sample;
-		vgmstream->loop_end_sample = loop_end_sample;
+    }
 
-		vgmstream->coding_type = coding_type;
-		if (channel_count==1)
-			vgmstream->layout_type = layout_none;
-		else
-			vgmstream->layout_type = layout_interleave;
-		vgmstream->meta_type = header_type;
-
-		vgmstream->interleave_block_size=18;
-		/* calculate filter coefficients */
-		{
-			double x,y,z,a,b,c;
-
-			x = cutoff;
-			y = vgmstream->sample_rate;
-			z = cos(2.0*M_PI*x/y);
-
-			a = M_SQRT2-z;
-			b = M_SQRT2-1.0;
-			c = (a-sqrt((a+b)*(a-b)))/b;
-
-			coef1 = floor(c*8192);
-			coef2 = floor(c*c*-4096);
-		}
-
-		{
-			int i;
-			STREAMFILE * chstreamfile;
-		   
-			/* ADX is so tightly interleaved that having two buffers is silly */
-			chstreamfile = streamFile->open(streamFile,filename,18*0x400);
-			if (!chstreamfile) goto fail;
-
-			for (i=0;i<channel_count;i++) {
-				vgmstream->ch[i].streamfile = chstreamfile;
-
-				vgmstream->ch[i].channel_start_offset=
-					vgmstream->ch[i].offset=
-					stream_offset+18*i;
-
-				vgmstream->ch[i].adpcm_coef[0] = coef1;
-				vgmstream->ch[i].adpcm_coef[1] = coef2;
-
-				if (coding_type == coding_CRI_ADX_enc_8 ||
-					coding_type == coding_CRI_ADX_enc_9)
-				{
-					int j;
-					vgmstream->ch[i].adx_channels = channel_count;
-					vgmstream->ch[i].adx_xor = xor_start;
-					vgmstream->ch[i].adx_mult = xor_mult;
-					vgmstream->ch[i].adx_add = xor_add;
-
-					for (j=0;j<i;j++)
-						adx_next_key(&vgmstream->ch[i]);
-				}
-			}
-		}
-	}
     return vgmstream;
 
     /* clean up anything we may have opened */

--- a/src/meta/dsp_adx.c
+++ b/src/meta/dsp_adx.c
@@ -1,0 +1,68 @@
+#include "meta.h"
+#include "../coding/coding.h"
+#include "../util.h"
+
+/* .ADX - from Xenoblade 3D */
+/* Xenoblade Chronicles 3D uses an adx extension as with
+ * the Wii version, but it's actually DSP ADPCM. */
+VGMSTREAM * init_vgmstream_dsp_adx(STREAMFILE *streamFile) {
+    VGMSTREAM * vgmstream = NULL;
+    int loop_flag, channel_count;
+    int channel_header_spacing = 0x34;
+	
+    /* check extension, case insensitive */
+    if (!check_extensions(streamFile,"adx")) goto fail;
+
+    /* check header */
+    if (read_32bitBE(0,streamFile)!=0x02000000) goto fail;
+
+    channel_count = read_32bitLE(0, streamFile);
+    loop_flag = read_16bitLE(0x6e, streamFile);
+
+    if (channel_count > 2 || channel_count < 0) goto fail;
+
+    vgmstream = allocate_vgmstream(channel_count,loop_flag);
+    if (!vgmstream) goto fail;
+
+    vgmstream->coding_type = coding_NGC_DSP;
+    vgmstream->layout_type = layout_none;
+    vgmstream->meta_type = meta_XB3D_ADX;
+    vgmstream->sample_rate = read_32bitLE(0x70,streamFile);
+    vgmstream->num_samples = read_32bitLE(0x74, streamFile);
+    vgmstream->loop_start_sample = read_32bitLE(0x78, streamFile);
+    vgmstream->loop_end_sample = read_32bitLE(0x7c, streamFile);
+
+    dsp_read_coefs_le(vgmstream,streamFile, 0x4, channel_header_spacing);
+
+
+    /* semi-interleave: manually open streams at offset */
+    {
+        char filename[PATH_LIMIT];
+        int i;
+
+        streamFile->get_name(streamFile,filename,sizeof(filename));
+        for (i = 0; i<channel_count; i++) {
+            vgmstream->ch[i].streamfile = streamFile->open(streamFile, filename, STREAMFILE_DEFAULT_BUFFER_SIZE);
+            vgmstream->ch[i].channel_start_offset =
+                    vgmstream->ch[i].offset = read_32bitLE(0x34+i*channel_header_spacing, streamFile);
+            if (!vgmstream->ch[i].streamfile) goto fail;
+        }
+    }
+
+#if 0
+    /* this should be equivalent to the above, but more testing is needed */
+    vgmstream->layout_type = layout_interleave;
+    vgmstream->interleave_block_size =
+            read_32bitLE(0x34+1*channel_header_spacing, streamFile)
+            - read_32bitLE(0x34+0*channel_header_spacing, streamFile);
+
+    if (!vgmstream_open_stream(vgmstream,streamFile, read_32bitLE(0x34+0*channel_header_spacing, streamFile)))
+        goto fail;
+#endif
+
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -668,4 +668,6 @@ VGMSTREAM * init_vgmstream_ps2_vds_vdm(STREAMFILE* streamFile);
 
 VGMSTREAM * init_vgmstream_x360_cxs(STREAMFILE* streamFile);
 
+VGMSTREAM * init_vgmstream_dsp_adx(STREAMFILE *streamFile);
+
 #endif /*_META_H*/

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -612,7 +612,8 @@ VGMSTREAM * init_vgmstream_hyperscan_kvag(STREAMFILE* streamFile);
 
 VGMSTREAM * init_vgmstream_ios_psnd(STREAMFILE* streamFile);
 
-VGMSTREAM * init_vgmstream_bos_adp(STREAMFILE* streamFile);
+VGMSTREAM * init_vgmstream_pc_adp_bos(STREAMFILE* streamFile);
+VGMSTREAM * init_vgmstream_pc_adp_otns(STREAMFILE* streamFile);
 
 VGMSTREAM * init_vgmstream_eb_sfx(STREAMFILE* streamFile);
 

--- a/src/meta/pc_adp.c
+++ b/src/meta/pc_adp.c
@@ -1,17 +1,14 @@
 #include "meta.h"
 #include "../util.h"
 
-/* ADP (from Balls of Steel) */
-VGMSTREAM * init_vgmstream_bos_adp(STREAMFILE *streamFile) {
+/* ADP - from Balls of Steel */
+VGMSTREAM * init_vgmstream_pc_adp_bos(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
-    char filename[PATH_LIMIT];
     off_t start_offset;
     int loop_flag = 0;
 	int channel_count;
 
-    /* check extension, case insensitive */
-    streamFile->get_name(streamFile,filename,sizeof(filename));
-    if (strcasecmp("adp",filename_extension(filename))) goto fail;
+    if (!check_extensions(streamFile,"adp")) goto fail;
 
     /* check header */
     if (read_32bitBE(0x00,streamFile) != 0x41445021) /* "ADP!" */
@@ -28,36 +25,68 @@ VGMSTREAM * init_vgmstream_bos_adp(STREAMFILE *streamFile) {
     start_offset = 0x18;
 	vgmstream->channels = channel_count;
     vgmstream->sample_rate = read_32bitLE(0x0C,streamFile);
-    vgmstream->coding_type = coding_DVI_IMA;
     vgmstream->num_samples = read_32bitLE(0x04,streamFile);
     if (loop_flag) {
         vgmstream->loop_start_sample = read_32bitLE(0x08,streamFile);
         vgmstream->loop_end_sample = vgmstream->num_samples;
     }
 
+    vgmstream->coding_type = coding_DVI_IMA;
     vgmstream->layout_type = layout_none;
     vgmstream->meta_type = meta_BOS_ADP;
 
-    /* open the file for reading */
-    {
-        STREAMFILE * file;
-        file = streamFile->open(streamFile,filename,STREAMFILE_DEFAULT_BUFFER_SIZE);
-        if (!file) goto fail;
-        vgmstream->ch[0].streamfile = file;
+    // 0x10, 0x12 - both initial history?
+    //vgmstream->ch[0].adpcm_history1_32 = read_16bitLE(0x10,streamFile);
+    // 0x14 - initial step index?
+    //vgmstream->ch[0].adpcm_step_index = read_32bitLE(0x14,streamFile);
 
-        vgmstream->ch[0].channel_start_offset=
-            vgmstream->ch[0].offset=start_offset;
-
-        // 0x10, 0x12 - both initial history?
-        //vgmstream->ch[0].adpcm_history1_32 = read_16bitLE(0x10,streamFile);
-        // 0x14 - initial step index?
-        //vgmstream->ch[0].adpcm_step_index = read_32bitLE(0x14,streamFile);
-    }
-
+    if (!vgmstream_open_stream(vgmstream, streamFile, start_offset))
+        goto fail;
     return vgmstream;
 
-    /* clean up anything we may have opened */
 fail:
-    if (vgmstream) close_vgmstream(vgmstream);
+    close_vgmstream(vgmstream);
+    return NULL;
+}
+
+/* ADP - from Omikron: The Nomad Soul (PC/DC) */
+VGMSTREAM * init_vgmstream_pc_adp_otns(STREAMFILE *streamFile) {
+    VGMSTREAM * vgmstream = NULL;
+    off_t start_offset, datasize;
+    int loop_flag = 0, channel_count, stereo_flag;
+
+    if (!check_extensions(streamFile,"adp")) goto fail;
+
+    /* no ID, only a basic 0x10 header with filesize and nulls; do some extra checks */
+    datasize = read_32bitLE(0x00,streamFile) & 0x00FFFFFF; /*24 bit*/
+    if (datasize + 0x10 != streamFile->get_size(streamFile)
+            && read_32bitLE(0x04,streamFile) != 0
+            && read_32bitLE(0x08,streamFile) != 0
+            && read_32bitLE(0x10,streamFile) != 0)
+        goto fail;
+
+    stereo_flag = read_8bit(0x03, streamFile);
+    if (stereo_flag > 1 || stereo_flag < 0) goto fail;
+    channel_count = stereo_flag ? 2 : 1;
+
+    /* build the VGMSTREAM */
+    vgmstream = allocate_vgmstream(channel_count,loop_flag);
+    if (!vgmstream) goto fail;
+
+    start_offset = 0x10;
+    vgmstream->channels = channel_count;
+    vgmstream->sample_rate = 22050;
+    vgmstream->num_samples = channel_count== 1 ? datasize*2 : datasize;
+
+    vgmstream->coding_type = coding_OTNS_IMA;
+    vgmstream->layout_type = layout_none;
+    vgmstream->meta_type = meta_OTNS_ADP;
+
+    if (!vgmstream_open_stream(vgmstream, streamFile, start_offset))
+        goto fail;
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
     return NULL;
 }

--- a/src/meta/ps2_vag.c
+++ b/src/meta/ps2_vag.c
@@ -20,7 +20,7 @@ VGMSTREAM * init_vgmstream_ps2_vag(STREAMFILE *streamFile) {
     int is_swag = 0;
 
     /* check extension, case insensitive */
-    if ( !check_extensions(streamFile,"vag,swag") )
+    if ( !check_extensions(streamFile,"vag,swag,str") )
         goto fail;
 
     /* check VAG Header */

--- a/src/meta/ps3_sgh_sgb.c
+++ b/src/meta/ps3_sgh_sgb.c
@@ -27,6 +27,7 @@ static int get_at3_riff_info(at3_riff_info* info, STREAMFILE *streamFile, int32_
 VGMSTREAM * init_vgmstream_ps3_sgdx(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
     STREAMFILE * streamHeader = NULL;
+    int32_t stream_size = 0;
     char filename[PATH_LIMIT];
 
     off_t start_offset, data_offset;
@@ -102,7 +103,6 @@ VGMSTREAM * init_vgmstream_ps3_sgdx(STREAMFILE *streamFile) {
         int32_t stream_sample_rate;
         int32_t stream_num_samples, stream_loop_start_sample, stream_loop_end_sample;
         off_t stream_start_offset;
-        int32_t stream_size;
 
         for (i=0; i < total_streams; i++) {
             if (i != target_stream) {
@@ -160,9 +160,9 @@ VGMSTREAM * init_vgmstream_ps3_sgdx(STREAMFILE *streamFile) {
             case 0x03: /* PSX ADPCM */
                 vgmstream->coding_type = coding_PSX;
                 vgmstream->layout_type = layout_interleave;
-                if (is_sgx) {
+                if (is_sgx || is_sgb) {
                     vgmstream->interleave_block_size = 0x10;
-                } else {
+                } else { //todo this only seems to happen with SFX
                     vgmstream->interleave_block_size = stream_size;
                 }
 
@@ -173,7 +173,7 @@ VGMSTREAM * init_vgmstream_ps3_sgdx(STREAMFILE *streamFile) {
             {
                 at3_riff_info info;
 
-                ffmpeg_data = init_ffmpeg_offset(streamFile, data_offset, streamFile->get_size(streamFile));
+                ffmpeg_data = init_ffmpeg_offset(streamFile, data_offset, stream_size);
                 if ( !ffmpeg_data ) goto fail;
 
                 vgmstream->coding_type = coding_FFmpeg;
@@ -203,7 +203,7 @@ VGMSTREAM * init_vgmstream_ps3_sgdx(STREAMFILE *streamFile) {
 
 #ifdef VGM_USE_FFMPEG
             case 0x06: /* AC3 */
-                ffmpeg_data = init_ffmpeg_offset(streamFile, data_offset, streamFile->get_size(streamFile));
+                ffmpeg_data = init_ffmpeg_offset(streamFile, data_offset, stream_size);
                 if ( !ffmpeg_data ) goto fail;
 
                 vgmstream->coding_type = coding_FFmpeg;

--- a/src/meta/ps3_sgh_sgb.c
+++ b/src/meta/ps3_sgh_sgb.c
@@ -27,39 +27,27 @@ static int get_at3_riff_info(at3_riff_info* info, STREAMFILE *streamFile, int32_
 VGMSTREAM * init_vgmstream_ps3_sgdx(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
     STREAMFILE * streamHeader = NULL;
-    int32_t stream_size = 0;
-    char filename[PATH_LIMIT];
 
     off_t start_offset, data_offset;
+    int32_t data_size;
 
-    int i;
-    int is_sgx, is_sgd, is_sgb;
+    int is_sgx, is_sgb;
+    int loop_flag, channels, type;
+    int sample_rate, num_samples, loop_start_sample, loop_end_sample;
 
-    int chunk_offset;
-    int total_streams;
-    int target_stream = 0; /* usually only SE use substreams */
-
-#ifdef VGM_USE_FFMPEG
-    ffmpeg_codec_data *ffmpeg_data = NULL;
-#endif
+    int target_stream = 0;
 
 
     /* check extension, case insensitive */
-    streamFile->get_name(streamFile,filename,sizeof(filename));
-    is_sgx = strcasecmp("sgx",filename_extension(filename))==0;
-    is_sgd = strcasecmp("sgd",filename_extension(filename))==0;
-    is_sgb = strcasecmp("sgb",filename_extension(filename))==0;
-    if ( !(is_sgx || is_sgd || is_sgb) )
+    if (!check_extensions(streamFile,"sgx,sgd,sgb"))
         goto fail;
+    is_sgx = check_extensions(streamFile,"sgx");
+    is_sgb = check_extensions(streamFile,"sgb");
+    //is_sgd = check_extensions(streamFile,"sgd");
 
     /* SGB+SGH: use SGH as header; otherwise use the current file as header */
     if (is_sgb) {
-        char fileheader[PATH_LIMIT];
-
-        strcpy(fileheader,filename);
-        strcpy(fileheader+strlen(fileheader)-3,"sgh");
-
-        streamHeader = streamFile->open(streamFile,fileheader,STREAMFILE_DEFAULT_BUFFER_SIZE);
+        streamHeader = open_stream_ext(streamFile, "sgh");
         if (!streamHeader) goto fail;
     } else {
         streamHeader = streamFile;
@@ -81,173 +69,133 @@ VGMSTREAM * init_vgmstream_ps3_sgdx(STREAMFILE *streamFile) {
     }
 
 
-    chunk_offset = 0x10;
     /* WAVE chunk (size 0x10 + files * 0x38 + optional padding) */
     /*  the format reads chunks until header_size, but we only want WAVE in the first position meaning BGM */
-    if (read_32bitBE(chunk_offset+0x00,streamHeader) != 0x57415645)  /* "WAVE" */
+    if (read_32bitBE(0x10,streamHeader) != 0x57415645)  /* "WAVE" */
         goto fail;
     /* 0x04  SGX: unknown; SGD/SGH: chunk length */
     /* 0x08  null */
 
-    /* usually only SE containers have multiple streams but just in case... */
-    total_streams = read_32bitLE(chunk_offset+0x0c,streamHeader);
-    if (target_stream+1 > total_streams)
-        goto fail;
-
-    /* read stream (skip until target_stream) */
-    chunk_offset += 0x10;
+    /* validate multi-streams (usually only SE containers) */
     {
-        int stream_loop_flag;
-        int stream_type;
-        int stream_channels;
-        int32_t stream_sample_rate;
-        int32_t stream_num_samples, stream_loop_start_sample, stream_loop_end_sample;
-        off_t stream_start_offset;
+        int total_streams = read_32bitLE(0x1c,streamHeader);
+        VGM_ASSERT(total_streams > 1, "SGXD: multiple streams found (%i entries)\n", total_streams);
+        if (target_stream == 0) target_stream = 1; /* auto: default to 1 */
+        if (target_stream > total_streams) goto fail;
+    }
 
-        for (i=0; i < total_streams; i++) {
-            if (i != target_stream) {
-                chunk_offset += 0x38; /* next file */
-                continue;
+    /* read stream header */
+    {
+        off_t chunk_offset, stream_offset;
+        chunk_offset = 0x10 + 0x10 + 0x38 * (target_stream-1); /* position in target header*/
+
+        /* 0x00  ? (00/01/02) */
+        /* 0x04  sometimes global offset to wave_name */
+        type = read_8bit(chunk_offset+0x08,streamHeader);
+        channels = read_8bit(chunk_offset+0x09,streamHeader);
+        /* 0x0a  null */
+        sample_rate = read_32bitLE(chunk_offset+0x0c,streamHeader);
+
+        /* 0x10  info_type: meaning of the next value
+         *  (00=null, 30/40=data size without padding (ADPCM, ATRAC3plus), 80/A0=block size (AC3) */
+        /* 0x14  info_value (see above) */
+        /* 0x18  unknown (ex. 0x0008/0010/3307/CC02/etc)x2 */
+        /* 0x1c  null */
+
+        num_samples = read_32bitLE(chunk_offset+0x20,streamHeader);
+        loop_start_sample = read_32bitLE(chunk_offset+0x24,streamHeader);
+        loop_end_sample = read_32bitLE(chunk_offset+0x28,streamHeader);
+        data_size = read_32bitLE(chunk_offset+0x2c,streamHeader); /* stream size (without padding) / interleave (for type3) */
+
+        if (is_sgx) {
+            stream_offset = 0x0; /* TODO unknown (not seen multi SGX) */
+        } else{
+            stream_offset = read_32bitLE(chunk_offset+0x30,streamHeader);
+        }
+        /* 0x34 SGX: unknown; SGD/SGH: stream size (with padding) / interleave */
+
+        loop_flag = loop_start_sample!=0xffffffff && loop_end_sample!=0xffffffff;
+        start_offset = data_offset + stream_offset;
+    }
+
+    /* build the VGMSTREAM */
+    vgmstream = allocate_vgmstream(channels,loop_flag);
+    if (!vgmstream) goto fail;
+
+    vgmstream->num_samples = num_samples;
+    vgmstream->sample_rate = sample_rate;
+    vgmstream->loop_start_sample = loop_start_sample;
+    vgmstream->loop_end_sample = loop_end_sample;
+
+    vgmstream->meta_type = meta_PS3_SGDX;
+
+    switch (type) {
+        case 0x03: /* PSX ADPCM */
+            vgmstream->coding_type = coding_PSX;
+            vgmstream->layout_type = layout_interleave;
+            if (is_sgx || is_sgb) {
+                vgmstream->interleave_block_size = 0x10;
+            } else { //todo this only seems to happen with SFX
+                vgmstream->interleave_block_size = data_size;
             }
 
-            /* 0x00  ? (00/01/02) */
-            /* 0x04  sometimes global offset to wave_name */
-            stream_type = read_8bit(chunk_offset+0x08,streamHeader);
-            stream_channels = read_8bit(chunk_offset+0x09,streamHeader);
-            /* 0x0a  null */
-            stream_sample_rate = read_32bitLE(chunk_offset+0x0c,streamHeader);
+            break;
 
-            /* 0x10  info_type: meaning of the next value
-             *  (00=null, 30/40=data size without padding (ADPCM, ATRAC3plus), 80/A0=block size (AC3) */
-            /* 0x14  info_value (see above) */
-            /* 0x18  unknown (ex. 0x0008/0010/3307/CC02/etc)x2 */
-            /* 0x1c  null */
+#ifdef VGM_USE_FFMPEG
+        case 0x04: { /* ATRAC3plus */
+            at3_riff_info info;
+            ffmpeg_codec_data *ffmpeg_data = init_ffmpeg_offset(streamFile, start_offset, data_size);
+            if ( !ffmpeg_data ) goto fail;
+            vgmstream->codec_data = ffmpeg_data;
+            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->layout_type = layout_none;
 
-            stream_num_samples = read_32bitLE(chunk_offset+0x20,streamHeader);
-            stream_loop_start_sample = read_32bitLE(chunk_offset+0x24,streamHeader);
-            stream_loop_end_sample = read_32bitLE(chunk_offset+0x28,streamHeader);
-            stream_size = read_32bitLE(chunk_offset+0x2c,streamHeader); /* stream size (without padding) / interleave (for type3) */
-
-            if (is_sgx) {
-                stream_start_offset = 0x0; /* TODO unknown (not seen multi SGX) */
-            } else{
-                stream_start_offset = read_32bitLE(chunk_offset+0x30,streamHeader);
+            /* manually fix looping due to FFmpeg bugs */
+            if (loop_flag && get_at3_riff_info(&info, streamFile, start_offset)) {
+                if (vgmstream->num_samples == info.fact_samples) { /* use if looks normal */
+                    /* todo use "skip samples"; for now we just use absolute loop values */
+                    vgmstream->loop_start_sample = info.loop_start_sample;
+                    vgmstream->loop_end_sample = info.loop_end_sample;
+                    vgmstream->num_samples += info.skip_samples; /* to ensure it always reaches loop_end */
+                }
             }
-            /* 0x34 SGX: unknown; SGD/SGH: stream size (with padding) / interleave */
-
-            stream_loop_flag = stream_loop_start_sample!=0xffffffff && stream_loop_end_sample!=0xffffffff;
-            chunk_offset += 0x38; /* next file */
 
             break;
         }
+#endif
+        case 0x05: /* Short VAG ADPCM */
+            vgmstream->coding_type = coding_PSX_cfg;
+            vgmstream->layout_type = layout_interleave;
+            vgmstream->interleave_block_size = 0x4;
 
-        /* build the VGMSTREAM */
-        vgmstream = allocate_vgmstream(stream_channels,stream_loop_flag);
-        if (!vgmstream) goto fail;
-
-        /* fill in the vital statistics */
-        vgmstream->num_samples = stream_num_samples;
-        vgmstream->sample_rate = stream_sample_rate;
-        vgmstream->channels = stream_channels;
-        if (stream_loop_flag) {
-            vgmstream->loop_start_sample = stream_loop_start_sample;
-            vgmstream->loop_end_sample = stream_loop_end_sample;
-        }
-
-        vgmstream->meta_type = meta_PS3_SGDX;
-
-        switch (stream_type) {
-            case 0x03: /* PSX ADPCM */
-                vgmstream->coding_type = coding_PSX;
-                vgmstream->layout_type = layout_interleave;
-                if (is_sgx || is_sgb) {
-                    vgmstream->interleave_block_size = 0x10;
-                } else { //todo this only seems to happen with SFX
-                    vgmstream->interleave_block_size = stream_size;
-                }
-
-                break;
+            break;
 
 #ifdef VGM_USE_FFMPEG
-            case 0x04: /* ATRAC3plus */
-            {
-                at3_riff_info info;
+        case 0x06: { /* AC3 */
+            ffmpeg_codec_data *ffmpeg_data = init_ffmpeg_offset(streamFile, start_offset, data_size);
+            if ( !ffmpeg_data ) goto fail;
+            vgmstream->codec_data = ffmpeg_data;
+            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->layout_type = layout_none;
 
-                ffmpeg_data = init_ffmpeg_offset(streamFile, data_offset, stream_size);
-                if ( !ffmpeg_data ) goto fail;
-
-                vgmstream->coding_type = coding_FFmpeg;
-                vgmstream->layout_type = layout_none;
-                /*vgmstream->meta_type = meta_FFmpeg;*/
-                vgmstream->codec_data = ffmpeg_data;
-
-                /* manually fix looping due to FFmpeg bugs */
-                if (stream_loop_flag && get_at3_riff_info(&info, streamFile, data_offset)) {
-                    if (vgmstream->num_samples == info.fact_samples) { /* use if looks normal */
-                        /* todo use "skip samples"; for now we just use absolute loop values */
-                        vgmstream->loop_start_sample = info.loop_start_sample;
-                        vgmstream->loop_end_sample = info.loop_end_sample;
-                        vgmstream->num_samples += info.skip_samples; /* to ensure it always reaches loop_end */
-                    }
-                }
-
-                break;
-            }
-#endif
-            case 0x05: /* Short VAG ADPCM */
-                vgmstream->coding_type = coding_PSX_cfg;
-                vgmstream->layout_type = layout_interleave;
-                vgmstream->interleave_block_size = 0x4;
-
-                break;
-
-#ifdef VGM_USE_FFMPEG
-            case 0x06: /* AC3 */
-                ffmpeg_data = init_ffmpeg_offset(streamFile, data_offset, stream_size);
-                if ( !ffmpeg_data ) goto fail;
-
-                vgmstream->coding_type = coding_FFmpeg;
-                vgmstream->layout_type = layout_none;
-                /*vgmstream->meta_type = meta_FFmpeg;*/
-                vgmstream->codec_data = ffmpeg_data;
-
-                break;
+            break;
+        }
 #endif
 
-            default:
-                goto fail;
-        }
-
-
-        start_offset = data_offset + stream_start_offset;
-        /* open the file for reading */
-        {
-            int i;
-            STREAMFILE * file;
-            file = streamFile->open(streamFile,filename,STREAMFILE_DEFAULT_BUFFER_SIZE);
-            if (!file) goto fail;
-
-            for (i=0; i < vgmstream->channels; i++) {
-                vgmstream->ch[i].streamfile = file;
-                vgmstream->ch[i].channel_start_offset =
-                        vgmstream->ch[i].offset =
-                                start_offset + vgmstream->interleave_block_size * i;
-            }
-        }
+        default:
+            goto fail;
     }
 
+    /* open the file for reading */
+    if (!vgmstream_open_stream(vgmstream,streamFile,start_offset))
+        goto fail;
 
+    if (is_sgb && streamHeader) close_streamfile(streamHeader);
     return vgmstream;
 
 fail:
-#ifdef VGM_USE_FFMPEG
-    if (ffmpeg_data) {
-        free_ffmpeg(ffmpeg_data);
-        vgmstream->codec_data = NULL;
-    }
-#endif
     if (is_sgb && streamHeader) close_streamfile(streamHeader);
-    if (vgmstream) close_vgmstream(vgmstream);
+    close_vgmstream(vgmstream);
     return NULL;
 }
 
@@ -260,8 +208,8 @@ fail:
  * FFmpeg doesn't support/export this, so we have to manually get the absolute values to fix looping.
  */
 static int get_at3_riff_info(at3_riff_info* info, STREAMFILE *streamFile, int32_t offset) {
-    off_t current_chunk, riff_size;
-    int data_found = 0;
+    off_t chunk_offset;
+    size_t chunk_size;
 
     memset(info, 0, sizeof(at3_riff_info));
 
@@ -269,51 +217,25 @@ static int get_at3_riff_info(at3_riff_info* info, STREAMFILE *streamFile, int32_
             && read_32bitBE(offset+0x8,streamFile)!=0x57415645 ) /* "WAVE" */
         goto fail;
 
-
-    /* read chunks */
-    riff_size = read_32bitLE(offset+0x4,streamFile);
-    current_chunk = offset + 0xc;
-
-    while (!data_found && current_chunk < riff_size) {
-        uint32_t chunk_type = read_32bitBE(current_chunk,streamFile);
-        off_t chunk_size = read_32bitLE(current_chunk+4,streamFile);
-
-        switch(chunk_type) {
-            case 0x736D706C:    /* smpl */
-                if (read_32bitLE(current_chunk+0x24, streamFile)==0
-                        || read_32bitLE(current_chunk+0x2c+0x4, streamFile)!=0 )
-                    goto fail;
-
-                info->loop_start_sample = read_32bitLE(current_chunk+0x2c+0x8, streamFile);
-                info->loop_end_sample = read_32bitLE(current_chunk+0x2c+0xc,streamFile);
-                break;
-
-            case 0x66616374:    /* fact */
-                if (chunk_size == 0x8) {
-                    info->fact_samples = read_32bitLE(current_chunk+0x8, streamFile);
-                    info->skip_samples = read_32bitLE(current_chunk+0xc, streamFile);
-                } else if (chunk_size == 0xc) {
-                    info->fact_samples = read_32bitLE(current_chunk+0x8, streamFile);
-                    info->skip_samples = read_32bitLE(current_chunk+0x10, streamFile);
-                } else {
-                    goto fail;
-                }
-                break;
-
-            case 0x64617461:    /* data */
-                data_found = 1;
-                break;
-
-            default:
-                break;
-        }
-
-        current_chunk += 8+chunk_size;
-    }
-
-    if (!data_found)
+    /*"smpl"*/
+    if (!find_chunk_le(streamFile, 0x736D706C,offset+0xc,0, &chunk_offset,&chunk_size)) goto fail;
+    if (read_32bitLE(chunk_offset+0x1C, streamFile)==0
+            || read_32bitLE(chunk_offset+0x24+0x4, streamFile)!=0 )
         goto fail;
+    info->loop_start_sample = read_32bitLE(chunk_offset+0x1C+0x8+0x8, streamFile);
+    info->loop_end_sample = read_32bitLE(chunk_offset+0x1C+0x8+0xc,streamFile);
 
+    /*"fact"*/
+    if (!find_chunk_le(streamFile, 0x66616374,offset+0xc,0, &chunk_offset,&chunk_size)) goto fail;
+    if (chunk_size == 0x8) {
+        info->fact_samples = read_32bitLE(chunk_offset+0x0, streamFile);
+        info->skip_samples = read_32bitLE(chunk_offset+0x4, streamFile);
+    } else if (chunk_size == 0xc) {
+        info->fact_samples = read_32bitLE(chunk_offset+0x0, streamFile);
+        info->skip_samples = read_32bitLE(chunk_offset+0x8, streamFile);
+    } else {
+        goto fail;
+    }
 
     /* found */
     return 1;

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -338,6 +338,7 @@ VGMSTREAM * (*init_vgmstream_fcns[])(STREAMFILE *streamFile) = {
     init_vgmstream_ps2_svag_snk,
     init_vgmstream_ps2_vds_vdm,
     init_vgmstream_x360_cxs,
+    init_vgmstream_dsp_adx,
 #ifdef VGM_USE_FFMPEG
     init_vgmstream_xma,
     init_vgmstream_mp4_aac_ffmpeg,

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -312,7 +312,8 @@ VGMSTREAM * (*init_vgmstream_fcns[])(STREAMFILE *streamFile) = {
 	init_vgmstream_ps2_wmus,
 	init_vgmstream_hyperscan_kvag,
 	init_vgmstream_ios_psnd,
-    init_vgmstream_bos_adp,
+	init_vgmstream_pc_adp_bos,
+	init_vgmstream_pc_adp_otns,
     init_vgmstream_eb_sfx,
     init_vgmstream_eb_sf0,
 	init_vgmstream_ps3_klbs,
@@ -1022,6 +1023,7 @@ int get_vgmstream_samples_per_frame(VGMSTREAM * vgmstream) {
         case coding_EACS_IMA:
         case coding_SNDS_IMA:
         case coding_IMA:
+        case coding_OTNS_IMA:
             return 1;
         case coding_INT_IMA:
         case coding_INT_DVI_IMA:
@@ -1155,6 +1157,7 @@ int get_vgmstream_frame_size(VGMSTREAM * vgmstream) {
         case coding_IMA:
         case coding_G721:
         case coding_SNDS_IMA:
+        case coding_OTNS_IMA:
             return 0;
         case coding_NGC_AFC:
             return 9;
@@ -1547,6 +1550,14 @@ void decode_vgmstream(VGMSTREAM * vgmstream, int samples_written, int samples_to
                         samples_to_do,chan);
             }
             break;
+        case coding_OTNS_IMA:
+            for (chan=0;chan<vgmstream->channels;chan++) {
+                decode_otns_ima(vgmstream, &vgmstream->ch[chan],buffer+samples_written*vgmstream->channels+chan,
+                        vgmstream->channels,vgmstream->samples_into_block,
+                        samples_to_do,chan);
+            }
+            break;
+
         case coding_WS:
             for (chan=0;chan<vgmstream->channels;chan++) {
                 decode_ws(vgmstream,chan,buffer+samples_written*vgmstream->channels+chan,

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -2308,14 +2308,6 @@ int vgmstream_open_stream(VGMSTREAM * vgmstream, STREAMFILE *streamFile, off_t s
     return 1;
 
 fail:
-    if (!use_streamfile_per_channel) {
-        streamFile->close(file); /* only one file was ever open */
-    } else {
-        for (ch=0; ch < vgmstream->channels; ch++) {
-            if (vgmstream->ch[ch].streamfile)
-                streamFile->close(vgmstream->ch[ch].streamfile); /* close all open files */
-        }
-    }
-
+    /* open streams will be closed in close_vgmstream(), hopefully called by the meta */
     return 0;
 }

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -119,6 +119,7 @@ typedef enum {
     coding_APPLE_IMA4,      /* Apple Quicktime IMA4 */
     coding_DAT4_IMA,        /* Eurocom 'DAT4' IMA ADPCM */
     coding_SNDS_IMA,        /* Heavy Iron Studios .snds IMA ADPCM */
+    coding_OTNS_IMA,        /* Omikron The Nomad Soul IMA ADPCM */
 
     coding_WS,              /* Westwood Studios VBR ADPCM */
     coding_MSADPCM,         /* Microsoft ADPCM */
@@ -564,6 +565,7 @@ typedef enum {
     meta_HYPERSCAN_KVAG,	// Hyperscan KVAG/BVG 
     meta_IOS_PSND,          // Crash Bandicoot Nitro Kart 2 (iOS)
     meta_BOS_ADP,           // ADP! (Balls of Steel, PC)
+    meta_OTNS_ADP,          // Omikron: The Nomad Soul .adp (PC/DC)
     meta_EB_SFX,            // Excitebots .sfx
     meta_EB_SF0,            // Excitebots .sf0
 	meta_PS3_KLBS,          // L@VE ONCE (PS3)


### PR DESCRIPTION
- Added Omikron: The Nomad Soul IMA .ADP
- Relaxed IDSP loop checks
- Fixed mono .ADS [Gauntlet Dark Legacy (GC/Xbox)]
- Fixed .MSA sample count [Psyvariar (PS2)]
- Added .str extension [Ben 10: Galactic Racing]
- Added basic multistream FSB4 support
- Fixed some SGXD
- (dev) Xenoblade 3D DSP .adx cleanup and minor fixes