### PR TITLE
AKB, etc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -311,7 +311,8 @@ META_OBJS=meta/adx_header.o \
     meta/ps2.o \
     meta/x360.o \
     meta/dsp_adx.o \
-    meta/bik.o
+    meta/bik.o \
+    meta/akb.o
 
 EXT_LIBS = ../ext_libs/clHCA.o
 

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -152,6 +152,8 @@ void decode_ffmpeg(VGMSTREAM *stream, sample * outbuf, int32_t samples_to_do, in
 void reset_ffmpeg(VGMSTREAM *vgmstream);
 void seek_ffmpeg(VGMSTREAM *vgmstream, int32_t num_sample);
 
+void ffmpeg_set_skip_samples(ffmpeg_codec_data * data, int skip_samples);
+
 int ffmpeg_make_riff_atrac3(uint8_t * buf, size_t buf_size, size_t sample_count, size_t data_size, int channels, int sample_rate, int block_align, int joint_stereo, int encoder_delay);
 int ffmpeg_make_riff_xma2(uint8_t * buf, size_t buf_size, size_t sample_count, size_t data_size, int channels, int sample_rate, int block_count, int block_size);
 int ffmpeg_make_riff_xma2_from_fmt(uint8_t * buf, size_t buf_size, off_t fmt_offset, size_t fmt_size, size_t data_size, STREAMFILE *streamFile, int big_endian);

--- a/src/formats.c
+++ b/src/formats.c
@@ -828,6 +828,7 @@ static const meta_info meta_info_list[] = {
         {meta_PS2_SVAG_SNK,         "SNK SVAG header"},
         {meta_PS2_VDS_VDM,          "Graffiti Kingdom VDS/VDM Header"},
         {meta_X360_CXS,             "CXS Header"},
+        {meta_AKB,                  "Square Enix AKB Header"},
 #ifdef VGM_USE_VORBIS
         {meta_OGG_VORBIS,           "Ogg Vorbis"},
         {meta_OGG_SLI,              "Ogg Vorbis with .sli (start,length) for looping"},

--- a/src/meta/Makefile.unix.am
+++ b/src/meta/Makefile.unix.am
@@ -252,5 +252,6 @@ libmeta_la_SOURCES += ps2.c
 libmeta_la_SOURCES += x360.c
 libmeta_la_SOURCES += dsp_adx.c
 libmeta_la_SOURCES += bik.c
+libmeta_la_SOURCES += akb.c
 
 EXTRA_DIST = meta.h

--- a/src/meta/akb.c
+++ b/src/meta/akb.c
@@ -2,6 +2,7 @@
 #include "meta.h"
 
 #if defined(VGM_USE_MP4V2) && defined(VGM_USE_FDKAAC)
+/* AKB (AAC only) - found in SQEX iOS games */
 VGMSTREAM * init_vgmstream_akb(STREAMFILE *streamFile) {
 	VGMSTREAM * vgmstream = NULL;
 
@@ -30,3 +31,169 @@ fail:
 	return NULL;
 }
 #endif
+
+
+/* AKB - found in SQEX iOS games */
+VGMSTREAM * init_vgmstream_akb_multi(STREAMFILE *streamFile) {
+    VGMSTREAM * vgmstream = NULL;
+    off_t start_offset;
+    size_t filesize;
+    int loop_flag = 0, channel_count, codec;
+
+    /* check extensions */
+    if ( !check_extensions(streamFile, "akb") )
+        goto fail;
+
+    /* check header */
+    if (read_32bitBE(0x00,streamFile) != 0x414B4220) /* "AKB " */
+        goto fail;
+
+    channel_count = read_8bit(0x0d,streamFile);
+    loop_flag = read_32bitLE(0x18,streamFile) > 0;
+
+    /* build the VGMSTREAM */
+    vgmstream = allocate_vgmstream(channel_count,loop_flag);
+    if (!vgmstream) goto fail;
+
+    /* 0x04: version? (iPad/IPhone?)  0x24: file_id? */
+    filesize = read_32bitLE(0x08,streamFile);
+    codec = read_8bit(0x0c,streamFile);
+    vgmstream->sample_rate = (uint16_t)read_16bitLE(0x0e,streamFile);
+    vgmstream->num_samples = read_32bitLE(0x10,streamFile);
+    vgmstream->loop_start_sample = read_32bitLE(0x14,streamFile);
+    vgmstream->loop_end_sample = read_32bitLE(0x18,streamFile);
+    /* 0x0c: some size based on codec  0x10+: unk stuff? 0xc0+: data stuff? */
+    vgmstream->meta_type = meta_AKB;
+
+    switch (codec) {
+#if 0
+        case 0x02: { /* some kind of ADPCM or PCM [various SFX] */
+            start_offset = 0xC4;
+            vgmstream->coding_type = coding_APPLE_IMA4;
+            vgmstream->layout_type = channel_count==1 ? layout_none : layout_interleave;
+            vgmstream->interleave_block_size = 0x100;
+            break;
+        }
+#endif
+
+#ifdef VGM_USE_FFMPEG
+        case 0x05: { /* ogg vorbis [Final Fantasy VI, Dragon Quest II-VI] */
+            /* Starting from an offset in the current libvorbis code is a bit hard so just use FFmpeg.
+             * Decoding seems to produce the same output with (inaudible) +-1 lower byte differences here and there. */
+            ffmpeg_codec_data *ffmpeg_data;
+
+            start_offset = 0xCC;
+            ffmpeg_data = init_ffmpeg_offset(streamFile, start_offset,filesize-start_offset);
+            if ( !ffmpeg_data ) goto fail;
+
+            vgmstream->codec_data = ffmpeg_data;
+            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->layout_type = layout_none;
+            /* These oggs have loop info in the comments, too */
+
+            break;
+        }
+
+        case 0x06: { /* aac [The World Ends with You (iPad)] */
+            /* init_vgmstream_akb above has priority, but this works fine too */
+            ffmpeg_codec_data *ffmpeg_data;
+
+            start_offset = 0x20;
+            ffmpeg_data = init_ffmpeg_offset(streamFile, start_offset,filesize-start_offset);
+            if ( !ffmpeg_data ) goto fail;
+
+            vgmstream->codec_data = ffmpeg_data;
+            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->layout_type = layout_none;
+
+            /* remove encoder delay from the "global" sample values */
+            vgmstream->num_samples -= ffmpeg_data->skipSamples;
+            vgmstream->loop_start_sample -= ffmpeg_data->skipSamples;
+            vgmstream->loop_end_sample -= ffmpeg_data->skipSamples;
+
+            break;
+        }
+#endif
+
+        /* AAC @20 in some cases? (see above) */
+        default:
+            goto fail;
+    }
+
+    /* open the file for reading */
+    if ( !vgmstream_open_stream(vgmstream, streamFile, start_offset) )
+        goto fail;
+
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}
+
+
+/* AKB2 - found in later SQEX iOS games */
+VGMSTREAM * init_vgmstream_akb2_multi(STREAMFILE *streamFile) {
+    VGMSTREAM * vgmstream = NULL;
+    off_t start_offset;
+    size_t datasize;
+    int loop_flag = 0, channel_count, codec;
+
+    /* check extensions */
+    if ( !check_extensions(streamFile, "akb") )
+        goto fail;
+
+    /* check header */
+    if (read_32bitBE(0x00,streamFile) != 0x414B4232) /* "AKB2" */
+        goto fail;
+
+    channel_count = read_8bit(0xd2,streamFile);
+    loop_flag = read_32bitLE(0xe4,streamFile) > 0;
+
+    /* build the VGMSTREAM */
+    vgmstream = allocate_vgmstream(channel_count,loop_flag);
+    if (!vgmstream) goto fail;
+
+    /* 0x04: version?  0x08: filesize,  0x28: file_id?,  others: no idea */
+    codec = read_8bit(0xd1,streamFile);
+    datasize = read_32bitLE(0xd8,streamFile);
+    vgmstream->sample_rate = (uint16_t)read_16bitLE(0xd6,streamFile);
+    /* When loop_flag num_samples may be much larger than real num_samples (it's fine when looping is off)
+     * Actual num_samples would be loop_end_sample+1, but more testing is needed */
+    vgmstream->num_samples = read_32bitLE(0xdc,streamFile);
+    vgmstream->loop_start_sample = read_32bitLE(0xe0,streamFile);
+    vgmstream->loop_end_sample = read_32bitLE(0xe4,streamFile);
+
+    start_offset = 0x120;
+    vgmstream->meta_type = meta_AKB;
+
+    switch (codec) {
+#ifdef VGM_USE_FFMPEG
+        case 0x05: { /* ogg vorbis [The World Ends with You (iPhone / latest update)] */
+            ffmpeg_codec_data *ffmpeg_data;
+
+            ffmpeg_data = init_ffmpeg_offset(streamFile, start_offset,datasize);
+            if ( !ffmpeg_data ) goto fail;
+
+            vgmstream->codec_data = ffmpeg_data;
+            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->layout_type = layout_none;
+
+            break;
+        }
+#endif
+
+        default:
+            goto fail;
+    }
+
+    /* open the file for reading */
+    if ( !vgmstream_open_stream(vgmstream, streamFile, start_offset) )
+        goto fail;
+
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/meta/ffmpeg.c
+++ b/src/meta/ffmpeg.c
@@ -452,10 +452,11 @@ static int init_seek(ffmpeg_codec_data * data) {
     if (ts == INT64_MIN)
         ts = 0;
 
-    /* apparently some (non-audio?) streams start with a DTS before 0, but some read_seeks expect 0, which would disrupt the index
-     *  we may need to keep start_ts around, since avstream/codec/format isn't always set */
+    /* Some streams start with negative DTS (observed in Ogg). For Ogg seeking to negative or 0 doesn't alter the output.
+     *  It does seem seeking before decoding alters a bunch of (inaudible) +-1 lower bytes though. */
+    VGM_ASSERT(ts != 0, "FFMPEG: negative start_ts (%i)\n", ts);
     if (ts != 0)
-        goto fail;
+        ts = 0;
 
     /* add index 0 */
     ret = av_add_index_entry(stream, pos, ts, size, distance, AVINDEX_KEYFRAME);

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -672,4 +672,8 @@ VGMSTREAM * init_vgmstream_x360_cxs(STREAMFILE* streamFile);
 
 VGMSTREAM * init_vgmstream_dsp_adx(STREAMFILE *streamFile);
 
+VGMSTREAM * init_vgmstream_akb_multi(STREAMFILE *streamFile);
+
+VGMSTREAM * init_vgmstream_akb2_multi(STREAMFILE *streamFile);
+
 #endif /*_META_H*/

--- a/src/meta/ngc_dsp_std.c
+++ b/src/meta/ngc_dsp_std.c
@@ -112,8 +112,13 @@ VGMSTREAM * init_vgmstream_ngc_dsp_std(STREAMFILE *streamFile) {
         off_t loop_off;
         /* check loop predictor/scale */
         loop_off = header.loop_start_offset/16*8;
-        if (header.loop_ps != (uint8_t)read_8bit(start_offset+loop_off,streamFile))
-            goto fail;
+        if (header.loop_ps != (uint8_t)read_8bit(start_offset+loop_off,streamFile)) {
+            /* rarely won't match (ex ESPN 2002), not sure if header or calc problem,  but doesn't seem to matter
+             *  (there may be a "click" when looping, or loop values may be too big and loop disabled anyway) */
+            VGM_LOG("DSP (std): bad loop_predictor\n");
+            //header.loop_flag = 0;
+            //goto fail;
+        }
     }
 
     /* compare num_samples with nibble count */

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -339,6 +339,9 @@ VGMSTREAM * (*init_vgmstream_fcns[])(STREAMFILE *streamFile) = {
     init_vgmstream_ps2_vds_vdm,
     init_vgmstream_x360_cxs,
     init_vgmstream_dsp_adx,
+    init_vgmstream_akb_multi,
+    init_vgmstream_akb2_multi,
+
 #ifdef VGM_USE_FFMPEG
     init_vgmstream_xma,
     init_vgmstream_mp4_aac_ffmpeg,

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -592,6 +592,7 @@ typedef enum {
     meta_PS2_SVAG_SNK,      /* SNK PS2 SVAG */
     meta_PS2_VDS_VDM,       /* Graffiti Kingdom */
     meta_X360_CXS,          /* Eternal Sonata (Xbox 360) */
+    meta_AKB,               /* SQEX iOS */
 
 #ifdef VGM_USE_VORBIS
     meta_OGG_VORBIS,        /* Ogg Vorbis */

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -859,6 +859,7 @@ typedef struct {
 
 #ifdef VGM_USE_FFMPEG
 typedef struct {
+    /*** init data ***/
     STREAMFILE *streamfile;
     
     // offset and total size of raw stream data
@@ -873,6 +874,7 @@ typedef struct {
     // header/fake RIFF over the real (parseable by FFmpeg) file start
     uint64_t header_size;
     
+    /*** "public" API (read-only) ***/
     // stream info
     int channels;
     int bitsPerSample;
@@ -883,7 +885,9 @@ typedef struct {
     int64_t totalSamples; // estimated count (may not be accurate for some demuxers)
     int64_t blockAlign; // coded block of bytes, counting channels (the block can be joint stereo)
     int64_t frameSize; // decoded samples per block
+    int64_t skipSamples; // number of start samples that will be skipped (encoder delay), for looping adjustments
     
+    /*** internal state ***/
     // Intermediate byte buffer
     uint8_t *sampleBuffer;
     // max samples we can held (can be less or more than frameSize)
@@ -904,6 +908,7 @@ typedef struct {
     int readNextPacket;
     int endOfStream;
     int endOfAudio;
+    int skipSamplesSet; // flag to know skip samples were manually added from vgmstream
     
     // Seeking is not ideal, so rollback is necessary
     int samplesToDiscard;


### PR DESCRIPTION
- Added AKB support for OGG/alt AAC [SQEX iOS: Dragon Quest 2-6, FF6, TWEWY]
- Relaxed loop validation in Nintendo "standard" DSP [ESPN 2002]
- (dev) FFmpeg preparations to fix some decoders with encoder delay

** for AKB OGG must recompile FFmpeg with these options:
--enable-decoder=vorbis
--enable-parser=vorbis

--enable-decoder=theora can be removed (I think I asked to include it before but I was actually thinking of vorbis, derp).

Since all formats using MP4V2/FDK (AKB,MP4) are now also implemented with FFmpeg, the dependency could be disabled I guess.
I don't know about the advantages or disadvantages of FFmpeg's AAC vs FDK's AAC though.
Right now FDK-AAC AKB has priority over FFmpeg-AAC AKB (meta goes before).
