### PR TITLE
Fairy Fencer F: Advent Dark Force Looping OGG support added.

### DIFF
--- a/src/meta/ogg_vorbis_file.c
+++ b/src/meta/ogg_vorbis_file.c
@@ -392,6 +392,13 @@ VGMSTREAM * init_vgmstream_ogg_vorbis_callbacks(STREAMFILE *streamFile, const ch
                 loop_flag=1;
                 loop_end_found=1;
             }
+            else if (strstr(comment->user_comments[i],"LOOPDEFS=")==
+                    comment->user_comments[i]) {
+                sscanf(strrchr(comment->user_comments[i],'=')+1,"%d,%d",
+                        &loop_start,&loop_end);
+                loop_flag=1;
+                loop_end_found=1;
+            }
             else if (strstr(comment->user_comments[i],"COMMENT=loop(")==
                     comment->user_comments[i]) {
                 sscanf(strrchr(comment->user_comments[i],'(')+1,"%d,%d",


### PR DESCRIPTION
Fairy Fencer F: Advent Dark Force was recently added to Steam ( http://store.steampowered.com/app/524580/ ). Unlike former Idea Factory/Compile Heart games which used XACT Soundbanks and Wavebanks for their audio data this game apparently switched to Looping OGG files which differ a slight bit from the existing files. (They work identically to the "lp=%d,%d" definition, just they decided to use LOOPDEFS=%d,%d).

This code change makes vgmstream support looping for those files. An example file is provided at:
https://mega.nz/#!PshGURyY!ttFSlP1-F0pzTxwVkIm3bA-wmMEUwOYffNSp3Y2zVhQ
Other game files have been tested as well using a foobar test compile.