### PR TITLE
Improve ADX support

### DIFF
--- a/src/coding/adx_decoder.c
+++ b/src/coding/adx_decoder.c
@@ -1,22 +1,23 @@
 #include "coding.h"
 #include "../util.h"
 
-void decode_adx(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do) {
+void decode_adx(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes) {
     int i;
     int32_t sample_count;
+    int32_t frame_samples = (frame_bytes - 2) * 2;
 
-    int framesin = first_sample/32;
+    int framesin = first_sample/frame_samples;
 
-    int32_t scale = read_16bitBE(stream->offset+framesin*18,stream->streamfile) + 1;
+    int32_t scale = read_16bitBE(stream->offset+framesin*frame_bytes,stream->streamfile) + 1;
     int32_t hist1 = stream->adpcm_history1_32;
     int32_t hist2 = stream->adpcm_history2_32;
     int coef1 = stream->adpcm_coef[0];
     int coef2 = stream->adpcm_coef[1];
 
-    first_sample = first_sample%32;
+    first_sample = first_sample%frame_samples;
 
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int sample_byte = read_8bit(stream->offset+framesin*18+2+i/2,stream->streamfile);
+        int sample_byte = read_8bit(stream->offset+framesin*frame_bytes +2+i/2,stream->streamfile);
 
         outbuf[sample_count] = clamp16(
                 (i&1?
@@ -39,22 +40,23 @@ void adx_next_key(VGMSTREAMCHANNEL * stream)
     stream->adx_xor = ( stream->adx_xor * stream->adx_mult + stream->adx_add ) & 0x7fff;
 }
 
-void decode_adx_enc(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do) {
+void decode_adx_enc(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes) {
     int i;
     int32_t sample_count;
+    int32_t frame_samples = (frame_bytes - 2) * 2;
 
-    int framesin = first_sample/32;
+    int framesin = first_sample/frame_samples;
 
-    int32_t scale = ((read_16bitBE(stream->offset+framesin*18,stream->streamfile) ^ stream->adx_xor)&0x1fff) + 1;
+    int32_t scale = ((read_16bitBE(stream->offset+framesin*frame_bytes,stream->streamfile) ^ stream->adx_xor)&0x1fff) + 1;
     int32_t hist1 = stream->adpcm_history1_32;
     int32_t hist2 = stream->adpcm_history2_32;
     int coef1 = stream->adpcm_coef[0];
     int coef2 = stream->adpcm_coef[1];
 
-    first_sample = first_sample%32;
+    first_sample = first_sample%frame_samples;
 
     for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
-        int sample_byte = read_8bit(stream->offset+framesin*18+2+i/2,stream->streamfile);
+        int sample_byte = read_8bit(stream->offset+framesin*frame_bytes +2+i/2,stream->streamfile);
 
         outbuf[sample_count] = clamp16(
                 (i&1?

--- a/src/coding/adx_decoder.c
+++ b/src/coding/adx_decoder.c
@@ -35,6 +35,41 @@ void decode_adx(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, 
     stream->adpcm_history2_32 = hist2;
 }
 
+void decode_adx_exp(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes) {
+    int i;
+    int32_t sample_count;
+    int32_t frame_samples = (frame_bytes - 2) * 2;
+
+    int framesin = first_sample/frame_samples;
+
+    int32_t scale = read_16bitBE(stream->offset+framesin*frame_bytes,stream->streamfile);
+    scale = 1 << (12 - scale);
+    int32_t hist1 = stream->adpcm_history1_32;
+    int32_t hist2 = stream->adpcm_history2_32;
+    int coef1 = stream->adpcm_coef[0];
+    int coef2 = stream->adpcm_coef[1];
+
+    first_sample = first_sample%frame_samples;
+
+    for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
+        int sample_byte = read_8bit(stream->offset+framesin*frame_bytes +2+i/2,stream->streamfile);
+
+        outbuf[sample_count] = clamp16(
+                (i&1?
+                 get_low_nibble_signed(sample_byte):
+                 get_high_nibble_signed(sample_byte)
+                ) * scale +
+                ((coef1 * hist1 + coef2 * hist2) >> 12)
+                );
+
+        hist2 = hist1;
+        hist1 = outbuf[sample_count];
+    }
+
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_history2_32 = hist2;
+}
+
 void decode_adx_fixed(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes) {
     int i;
     int32_t sample_count;

--- a/src/coding/adx_decoder.c
+++ b/src/coding/adx_decoder.c
@@ -35,6 +35,41 @@ void decode_adx(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, 
     stream->adpcm_history2_32 = hist2;
 }
 
+void decode_adx_fixed(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes) {
+    int i;
+    int32_t sample_count;
+    int32_t frame_samples = (frame_bytes - 2) * 2;
+
+    int framesin = first_sample/frame_samples;
+
+    int32_t scale = (read_16bitBE(stream->offset + framesin*frame_bytes, stream->streamfile) & 0x1FFF) + 1;
+    int32_t predictor = read_8bit(stream->offset + framesin*frame_bytes, stream->streamfile) >> 5;
+    int32_t hist1 = stream->adpcm_history1_32;
+    int32_t hist2 = stream->adpcm_history2_32;
+    int coef1 = stream->adpcm_coef[predictor * 2];
+    int coef2 = stream->adpcm_coef[predictor * 2 + 1];
+
+    first_sample = first_sample%frame_samples;
+
+    for (i=first_sample,sample_count=0; i<first_sample+samples_to_do; i++,sample_count+=channelspacing) {
+        int sample_byte = read_8bit(stream->offset+framesin*frame_bytes +2+i/2,stream->streamfile);
+
+        outbuf[sample_count] = clamp16(
+                (i&1?
+                 get_low_nibble_signed(sample_byte):
+                 get_high_nibble_signed(sample_byte)
+                ) * scale +
+                ((coef1 * hist1 + coef2 * hist2) >> 12)
+                );
+
+        hist2 = hist1;
+        hist1 = outbuf[sample_count];
+    }
+
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_history2_32 = hist2;
+}
+
 void adx_next_key(VGMSTREAMCHANNEL * stream)
 {
     stream->adx_xor = ( stream->adx_xor * stream->adx_mult + stream->adx_add ) & 0x7fff;

--- a/src/coding/adx_decoder.c
+++ b/src/coding/adx_decoder.c
@@ -24,7 +24,7 @@ void decode_adx(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, 
                  get_low_nibble_signed(sample_byte):
                  get_high_nibble_signed(sample_byte)
                 ) * scale +
-                ((coef1 * hist1 + coef2 * hist2) >> 12)
+                (coef1 * hist1 >> 12) + (coef2 * hist2 >> 12)
                 );
 
         hist2 = hist1;
@@ -59,7 +59,7 @@ void decode_adx_exp(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspaci
                  get_low_nibble_signed(sample_byte):
                  get_high_nibble_signed(sample_byte)
                 ) * scale +
-                ((coef1 * hist1 + coef2 * hist2) >> 12)
+                (coef1 * hist1 >> 12) + (coef2 * hist2 >> 12)
                 );
 
         hist2 = hist1;
@@ -94,7 +94,7 @@ void decode_adx_fixed(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspa
                  get_low_nibble_signed(sample_byte):
                  get_high_nibble_signed(sample_byte)
                 ) * scale +
-                ((coef1 * hist1 + coef2 * hist2) >> 12)
+                (coef1 * hist1 >> 12) + (coef2 * hist2 >> 12)
                 );
 
         hist2 = hist1;
@@ -133,7 +133,7 @@ void decode_adx_enc(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspaci
                  get_low_nibble_signed(sample_byte):
                  get_high_nibble_signed(sample_byte)
                 ) * scale +
-                ((coef1 * hist1 + coef2 * hist2) >> 12)
+                (coef1 * hist1 >> 12) + (coef2 * hist2 >> 12)
                 );
 
         hist2 = hist1;

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -4,8 +4,8 @@
 #include "../vgmstream.h"
 
 /* adx_decoder */
-void decode_adx(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do);
-void decode_adx_enc(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do);
+void decode_adx(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes);
+void decode_adx_enc(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes);
 void adx_next_key(VGMSTREAMCHANNEL * stream);
 
 /* g721_decoder */

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -5,6 +5,7 @@
 
 /* adx_decoder */
 void decode_adx(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes);
+void decode_adx_exp(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes);
 void decode_adx_fixed(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes);
 void decode_adx_enc(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes);
 void adx_next_key(VGMSTREAMCHANNEL * stream);

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -5,6 +5,7 @@
 
 /* adx_decoder */
 void decode_adx(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes);
+void decode_adx_fixed(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes);
 void decode_adx_enc(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int32_t frame_bytes);
 void adx_next_key(VGMSTREAMCHANNEL * stream);
 

--- a/src/formats.c
+++ b/src/formats.c
@@ -388,6 +388,7 @@ static const coding_info coding_info_list[] = {
         {coding_PCM8_int,           "8-bit PCM with 1 byte interleave"},
         {coding_PCM8_SB_int,        "8-bit PCM with sign bit, 1 byte interleave"},
         {coding_CRI_ADX,            "CRI ADX 4-bit ADPCM"},
+        {coding_CRI_ADX_exp,        "CRI ADX 4-bit ADPCM with exponential scale"},
         {coding_CRI_ADX_fixed,      "CRI ADX 4-bit ADPCM with fixed coefficients"},
         {coding_CRI_ADX_enc_8,      "CRI ADX 4-bit ADPCM (type 8 encryption)"},
         {coding_CRI_ADX_enc_9,      "CRI ADX 4-bit ADPCM (type 8 encryption)"},

--- a/src/formats.c
+++ b/src/formats.c
@@ -388,6 +388,7 @@ static const coding_info coding_info_list[] = {
         {coding_PCM8_int,           "8-bit PCM with 1 byte interleave"},
         {coding_PCM8_SB_int,        "8-bit PCM with sign bit, 1 byte interleave"},
         {coding_CRI_ADX,            "CRI ADX 4-bit ADPCM"},
+        {coding_CRI_ADX_fixed,      "CRI ADX 4-bit ADPCM with fixed coefficients"},
         {coding_CRI_ADX_enc_8,      "CRI ADX 4-bit ADPCM (type 8 encryption)"},
         {coding_CRI_ADX_enc_9,      "CRI ADX 4-bit ADPCM (type 8 encryption)"},
         {coding_NGC_DSP,            "Nintendo DSP 4-bit ADPCM"},

--- a/src/meta/adx.c
+++ b/src/meta/adx.c
@@ -188,8 +188,8 @@ VGMSTREAM * init_vgmstream_adx(STREAMFILE *streamFile) {
         b = M_SQRT2-1.0;
         c = (a-sqrt((a+b)*(a-b)))/b;
 
-        coef1 = floor(c*8192);
-        coef2 = floor(c*c*-4096);
+        coef1 = (short)(c*8192);
+        coef2 = (short)(c*c*-4096);
 
         int i;
         for (i = 0; i < channel_count; i++) {

--- a/src/meta/adx.c
+++ b/src/meta/adx.c
@@ -18,6 +18,7 @@ VGMSTREAM * init_vgmstream_adx(STREAMFILE *streamFile) {
     int loop_flag = 0, channel_count;
     int32_t loop_start_sample = 0, loop_end_sample = 0;
     uint16_t version_signature;
+    uint8_t frame_size;
 
     meta_t header_type;
     coding_t coding_type = coding_CRI_ADX;
@@ -42,8 +43,7 @@ VGMSTREAM * init_vgmstream_adx(STREAMFILE *streamFile) {
      * ADX with exponential scale, 0x10 is AHX for DC, 0x11 is AHX */
     if (read_8bit(0x04,streamFile) != 3) goto fail;
 
-    /* check for frame size (only 18 is supported at the moment) */
-    if (read_8bit(0x05,streamFile) != 18) goto fail;
+    frame_size = read_8bit(0x05, streamFile);
 
     /* check for bits per sample? (only 4 makes sense for ADX) */
     if (read_8bit(0x06,streamFile) != 4) goto fail;
@@ -142,7 +142,7 @@ VGMSTREAM * init_vgmstream_adx(STREAMFILE *streamFile) {
 
     vgmstream->coding_type = coding_type;
     vgmstream->layout_type = channel_count==1 ? layout_none : layout_interleave;
-    vgmstream->interleave_block_size = 18;
+    vgmstream->interleave_block_size = frame_size;
     vgmstream->meta_type = header_type;
 
 

--- a/src/meta/adx.c
+++ b/src/meta/adx.c
@@ -22,7 +22,7 @@ VGMSTREAM * init_vgmstream_adx(STREAMFILE *streamFile) {
     uint8_t frame_size;
 
     meta_t header_type;
-    coding_t coding_type = coding_CRI_ADX;
+    coding_t coding_type;
     int16_t coef1, coef2;
     uint16_t xor_start=0,xor_mult=0,xor_add=0;
 
@@ -43,9 +43,20 @@ VGMSTREAM * init_vgmstream_adx(STREAMFILE *streamFile) {
     /* 0x02 is for some unknown fixed filter, 0x03 is standard ADX, 0x04 is
      * ADX with exponential scale, 0x10 is AHX for DC, 0x11 is AHX */
     encoding_type = read_8bit(0x04, streamFile);
-    if (encoding_type != 2 && encoding_type != 3) goto fail;
-    if (encoding_type == 2)
-        coding_type = coding_CRI_ADX_fixed;
+
+    switch (encoding_type) {
+        case 2:
+            coding_type = coding_CRI_ADX_fixed;
+            break;
+        case 3:
+            coding_type = coding_CRI_ADX;
+            break;
+        case 4:
+            coding_type = coding_CRI_ADX_exp;
+            break;
+        default:
+            goto fail;
+    }
 
     frame_size = read_8bit(0x05, streamFile);
 
@@ -182,8 +193,8 @@ VGMSTREAM * init_vgmstream_adx(STREAMFILE *streamFile) {
 
         int i;
         for (i = 0; i < channel_count; i++) {
-            vgmstream->ch[i].adpcm_coef[0] == coef1;
-            vgmstream->ch[i].adpcm_coef[1] == coef2;
+            vgmstream->ch[i].adpcm_coef[0] = coef1;
+            vgmstream->ch[i].adpcm_coef[1] = coef2;
         }
     }
 

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -936,6 +936,7 @@ int get_vgmstream_samples_per_frame(VGMSTREAM * vgmstream) {
         case coding_CRI_ADX:
         case coding_CRI_ADX_enc_8:
         case coding_CRI_ADX_enc_9:
+			return (vgmstream->interleave_block_size - 2) * 2;
         case coding_L5_555:
             return 32;
         case coding_NGC_DSP:
@@ -1215,7 +1216,8 @@ void decode_vgmstream(VGMSTREAM * vgmstream, int samples_written, int samples_to
             for (chan=0;chan<vgmstream->channels;chan++) {
                 decode_adx(&vgmstream->ch[chan],buffer+samples_written*vgmstream->channels+chan,
                         vgmstream->channels,vgmstream->samples_into_block,
-                        samples_to_do);
+                        samples_to_do,
+                        vgmstream->interleave_block_size);
             }
 
             break;
@@ -1224,7 +1226,8 @@ void decode_vgmstream(VGMSTREAM * vgmstream, int samples_written, int samples_to
             for (chan=0;chan<vgmstream->channels;chan++) {
                 decode_adx_enc(&vgmstream->ch[chan],buffer+samples_written*vgmstream->channels+chan,
                         vgmstream->channels,vgmstream->samples_into_block,
-                        samples_to_do);
+                        samples_to_do,
+                        vgmstream->interleave_block_size);
             }
 
             break;

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -935,6 +935,7 @@ int get_vgmstream_samples_per_frame(VGMSTREAM * vgmstream) {
     switch (vgmstream->coding_type) {
         case coding_CRI_ADX:
         case coding_CRI_ADX_fixed:
+        case coding_CRI_ADX_exp:
         case coding_CRI_ADX_enc_8:
         case coding_CRI_ADX_enc_9:
 			return (vgmstream->interleave_block_size - 2) * 2;
@@ -1087,6 +1088,7 @@ int get_vgmstream_frame_size(VGMSTREAM * vgmstream) {
     switch (vgmstream->coding_type) {
         case coding_CRI_ADX:
         case coding_CRI_ADX_fixed:
+        case coding_CRI_ADX_exp:
         case coding_CRI_ADX_enc_8:
         case coding_CRI_ADX_enc_9:
             return vgmstream->interleave_block_size;
@@ -1218,6 +1220,15 @@ void decode_vgmstream(VGMSTREAM * vgmstream, int samples_written, int samples_to
         case coding_CRI_ADX:
             for (chan=0;chan<vgmstream->channels;chan++) {
                 decode_adx(&vgmstream->ch[chan],buffer+samples_written*vgmstream->channels+chan,
+                        vgmstream->channels,vgmstream->samples_into_block,
+                        samples_to_do,
+                        vgmstream->interleave_block_size);
+            }
+
+            break;
+        case coding_CRI_ADX_exp:
+            for (chan=0;chan<vgmstream->channels;chan++) {
+                decode_adx_exp(&vgmstream->ch[chan],buffer+samples_written*vgmstream->channels+chan,
                         vgmstream->channels,vgmstream->samples_into_block,
                         samples_to_do,
                         vgmstream->interleave_block_size);

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -934,6 +934,7 @@ void render_vgmstream(sample * buffer, int32_t sample_count, VGMSTREAM * vgmstre
 int get_vgmstream_samples_per_frame(VGMSTREAM * vgmstream) {
     switch (vgmstream->coding_type) {
         case coding_CRI_ADX:
+        case coding_CRI_ADX_fixed:
         case coding_CRI_ADX_enc_8:
         case coding_CRI_ADX_enc_9:
 			return (vgmstream->interleave_block_size - 2) * 2;
@@ -1085,8 +1086,10 @@ int get_vgmstream_samples_per_shortframe(VGMSTREAM * vgmstream) {
 int get_vgmstream_frame_size(VGMSTREAM * vgmstream) {
     switch (vgmstream->coding_type) {
         case coding_CRI_ADX:
+        case coding_CRI_ADX_fixed:
         case coding_CRI_ADX_enc_8:
         case coding_CRI_ADX_enc_9:
+            return vgmstream->interleave_block_size;
         case coding_L5_555:
             return 18;
         case coding_NGC_DSP:
@@ -1215,6 +1218,15 @@ void decode_vgmstream(VGMSTREAM * vgmstream, int samples_written, int samples_to
         case coding_CRI_ADX:
             for (chan=0;chan<vgmstream->channels;chan++) {
                 decode_adx(&vgmstream->ch[chan],buffer+samples_written*vgmstream->channels+chan,
+                        vgmstream->channels,vgmstream->samples_into_block,
+                        samples_to_do,
+                        vgmstream->interleave_block_size);
+            }
+
+            break;
+        case coding_CRI_ADX_fixed:
+            for (chan=0;chan<vgmstream->channels;chan++) {
+                decode_adx_fixed(&vgmstream->ch[chan],buffer+samples_written*vgmstream->channels+chan,
                         vgmstream->channels,vgmstream->samples_into_block,
                         samples_to_do,
                         vgmstream->interleave_block_size);

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -86,6 +86,7 @@ typedef enum {
 
     /* 4-bit ADPCM */
     coding_CRI_ADX,         /* CRI ADX */
+    coding_CRI_ADX_fixed,   /* CRI ADX, encoding type 2 with fixed coefficients */
     coding_CRI_ADX_enc_8,   /* CRI ADX, type 8 encryption (God Hand) */
     coding_CRI_ADX_enc_9,   /* CRI ADX, type 9 encryption (PSO2) */
 

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -87,6 +87,7 @@ typedef enum {
     /* 4-bit ADPCM */
     coding_CRI_ADX,         /* CRI ADX */
     coding_CRI_ADX_fixed,   /* CRI ADX, encoding type 2 with fixed coefficients */
+    coding_CRI_ADX_exp,     /* CRI ADX, encoding type 4 with exponential scale */
     coding_CRI_ADX_enc_8,   /* CRI ADX, type 8 encryption (God Hand) */
     coding_CRI_ADX_enc_9,   /* CRI ADX, type 9 encryption (PSO2) */
 


### PR DESCRIPTION
- Improve ADX decoding accuracy.

Add support for:
- Varying ADX frame sizes
- ADX files with encoding type 2. These files use predetermined coefficients.
- ADX files with encoding type 4. These files use an exponential scale.