### PR TITLE
Fix compile errors for BFWAV

### DIFF
--- a/src/meta/bfwav.c
+++ b/src/meta/bfwav.c
@@ -111,7 +111,7 @@ VGMSTREAM * init_vgmstream_bfwav(STREAMFILE *streamFile) {
 				if ((uint32_t)read_16bit(coeffheader, streamFile) != 0x1F00) goto fail;
 
 				off_t coef_offset = read_32bit(coeffheader + 0xC, streamFile) + coeffheader;
-				vgmstream->ch[j].adpcm_coef[i] = read_16bit(coef_offset + j*coef_spacing + i * 2, streamFile);
+				vgmstream->ch[j].adpcm_coef[i] = read_16bit(coef_offset + i * 2, streamFile);
 			}
 		}
 	}


### PR DESCRIPTION
Apparently my last PR had a compilation error which didn't show up on *nix building? Either way the coef_spacing variable is gone from that spot.