### PR TITLE
Various updates to the Autotools build system

### DIFF
--- a/Makefile.audacious.am
+++ b/Makefile.audacious.am
@@ -3,6 +3,6 @@
 
 AM_MAKEFLAGS=-f Makefile.audacious
 
-SUBDIRS = src audacious
+SUBDIRS = src audacious test
 
-#EXTRA_DIST = include 
+EXTRA_DIST = version.h

--- a/audacious/Makefile.audacious.am
+++ b/audacious/Makefile.audacious.am
@@ -1,11 +1,12 @@
 ## audacious-vgmstream automake script
 
-lib_LTLIBRARIES = libvgmstream.la
+#inputplugindir = $(libdir)/audacious/$(INPUT_PLUGIN_DIR)
+inputplugindir = $(plugindir)/$(INPUT_PLUGIN_DIR)
 
-libdir = @plugindir@/@INPUT_PLUGIN_DIR@
+inputplugin_LTLIBRARIES = libvgmstream.la
 
 AM_MAKEFLAGS=-f Makefile.audacious
-AM_CXXFLAGS = -DVERSION=\"VGMSTREAM_VERSION\" -Wall -std=c++11 -fpermissive @CXXFLAGS@ -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/ @GTK_CFLAGS@
+AM_CXXFLAGS = -DVERSION=\"VGMSTREAM_VERSION\" -Wall -std=c++11 -fpermissive -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/ $(AUDACIOUS_CFLAGS) $(GTK_CFLAGS)
 AM_LIBS =
 
 # sources/headers are updated automatically by ./bootstrap script (not all headers are needed though)

--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,10 @@ PKG_CHECK_MODULES(AUDACIOUS, [audacious >= 3.5.0],,
         [AC_MSG_ERROR([Cannot find audacious >= 3.5.0 correctly installed])]
 )
 
+PKG_CHECK_MODULES(VORBIS, [vorbis],,
+        [AC_MSG_ERROR([Cannot find libvorbis])]
+)
+
 PKG_CHECK_MODULES(VORBISFILE, [vorbisfile],,
         [AC_MSG_ERROR([Cannot find libvorbisfile])]
 )
@@ -33,8 +37,10 @@ PKG_CHECK_MODULES(GTK, [glib-2.0 >= 2.6.0 gtk+-2.0 >= 2.6.0 gthread-2.0 pango],
     , [AC_MSG_ERROR([Cannot find glib2/gtk2/pango])]
 )
 
-CFLAGS="$CFLAGS $AUDACIOUS_CFLAGS"
-LIBS="$LIBS $AUDACIOUS_LIBS $GTK_LIBS $VORBISFILE_LIBS $MPG123_LIBS"
+if test "_$GCC" = _yes
+then
+  CFLAGS="$CFLAGS -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wno-unused-but-set-variable"
+fi
 
 plugindir=`pkg-config audacious --variable=plugin_dir`
 AC_SUBST(plugindir)
@@ -55,4 +61,5 @@ AC_OUTPUT([
   src/layout/Makefile.audacious
   src/meta/Makefile.audacious
   audacious/Makefile.audacious
+  test/Makefile.audacious
 ])

--- a/src/Makefile.audacious.am
+++ b/src/Makefile.audacious.am
@@ -1,8 +1,8 @@
 ## audacious-vgmstream automake script
 
-noinst_LTLIBRARIES = libvgmstream.la
+lib_LTLIBRARIES = libvgmstream.la
 
-AM_CFLAGS = -Wall @CFLAGS@ -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
+AM_CFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
 AM_MAKEFLAGS=-f Makefile.audacious
 
 SUBDIRS = coding layout meta
@@ -11,5 +11,6 @@ SUBDIRS = coding layout meta
 libvgmstream_la_LDFLAGS = coding/libcoding.la layout/liblayout.la meta/libmeta.la
 libvgmstream_la_SOURCES = (auto-updated)
 libvgmstream_la_SOURCES += ../ext_libs/clHCA.c
+libvgmstream_la_LIBADD = $(AUDACIOUS_LIBS) $(GTK_LIBS) $(VORBISFILE_LIBS) $(VORBIS_LIBS) $(MPG123_LIBS) -lm
 EXTRA_DIST = (auto-updated)
 EXTRA_DIST += ../ext_includes/clHCA.h

--- a/src/coding/Makefile.audacious.am
+++ b/src/coding/Makefile.audacious.am
@@ -2,7 +2,7 @@
 
 noinst_LTLIBRARIES = libcoding.la
 
-AM_CFLAGS = -Wall @CFLAGS@ -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
+AM_CFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
 AM_MAKEFLAGS=-f Makefile.audacious
 
 # sources/headers are updated automatically by ./bootstrap script (not all headers are needed though)

--- a/src/layout/Makefile.audacious.am
+++ b/src/layout/Makefile.audacious.am
@@ -2,7 +2,7 @@
 
 noinst_LTLIBRARIES = liblayout.la
 
-AM_CFLAGS = -Wall @CFLAGS@ -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
+AM_CFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
 AM_MAKEFLAGS=-f Makefile.audacious
 
 # sources/headers are updated automatically by ./bootstrap script (not all headers are needed though)

--- a/src/meta/Makefile.audacious.am
+++ b/src/meta/Makefile.audacious.am
@@ -2,7 +2,7 @@
 
 noinst_LTLIBRARIES = libmeta.la
 
-AM_CFLAGS = -Wall @CFLAGS@ -DVAR_ARRAYS -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
+AM_CFLAGS = -DVAR_ARRAYS -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
 AM_MAKEFLAGS=-f Makefile.audacious
 
 # sources/headers are updated automatically by ./bootstrap script (not all headers are needed though)

--- a/test/Makefile.audacious.am
+++ b/test/Makefile.audacious.am
@@ -1,0 +1,9 @@
+## audacious-vgmstream automake script
+
+bin_PROGRAMS = vgmstream-cli
+
+AM_CFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/ $(AO_CFLAGS)
+AM_MAKEFLAGS = -f Makefile.audacious
+
+vgmstream_cli_SOURCES = test.c
+vgmstream_cli_LDADD   = ../src/libvgmstream.la

--- a/unbootstrap
+++ b/unbootstrap
@@ -1,4 +1,4 @@
 #!/bin/sh
 # audacious-vgmstream script - reverses the actions of bootstrap
 
-rm -rf configure AUTHORS depcomp ChangeLog config.guess ltmain.sh README config.sub autom4te.cache Makefile.audacious.in INSTALL missing NEWS aclocal.m4 install-sh audacious/config.h.in audacious/main.loT audacious/Makefile.audacious.in src/Makefile.audacious.in src/coding/Makefile.audacious.in src/meta/Makefile.audacious.in src/layout/Makefile.audacious.in
+rm -rf configure AUTHORS compile depcomp ChangeLog config.guess ltmain.sh README config.sub autom4te.cache Makefile.audacious.in INSTALL missing NEWS aclocal.m4 install-sh audacious/config.h.in audacious/main.loT audacious/Makefile.audacious.in src/Makefile.audacious.in src/coding/Makefile.audacious.in src/meta/Makefile.audacious.in src/layout/Makefile.audacious.in


### PR DESCRIPTION
This is a handful of cleanups/fixes to the Autotools build system. The test program can now be built this way, with the name "vgmstream-cli", as discussed in #144. Developed and tested on Ubuntu Linux.

----

Makefile.audacious.am:

* Add test/ subdirectory to the Autotools build

* Add version.h to EXTRA_DIST so that "make distcheck" passes

audacious/Makefile.audacious.am:

* Install Audacious plug-in into the appropriate directory

* No need to include CXXFLAGS in AM_CXXFLAGS, as the former is already
  included in the compiler invocation

configure.ac:

* Need to link to libvorbis in order for static-library builds
  (--disable-shared) to link correctly

* Only add GCC-specific compiler flags if GCC is detected

* Tightened up the GCC warning flags

* Don't set LIBS, so that different targets can link against different
  libraries

* Generate makefile for test/ subdirectory

src/Makefile.audacious.am:

* Install libvgmstream into the library directory

* Removed GCC-specific flag from AM_CFLAGS

* No need to include CFLAGS in AM_CFLAGS, as the former is already
  included in the compiler invocation

* Add libvgmstream dependencies via LIBADD instead of global LIBS var

test/Makefile.audacious.am:

* New makefile template for test/ subdirectory

unbootstrap:

* Also remove "compile" script from bootstrap