### PR TITLE
ATRAC9, etc

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -111,14 +111,14 @@ cd vgmstream
 
 ./bootstrap
 ./configure
-make -f Makefile.audacious
+make -f Makefile.autotools
 
 # copy to audacious plugins
-sudo make -f Makefile.audacious install
+sudo make -f Makefile.autotools install
 
 
 # optional post-cleanup
-make -f Makefile.audacious clean
+make -f Makefile.autotools clean
 find . -name ".deps" -type d -exec rm -r "{}" \;
 ./unbootstrap
 ## WARNING, removes *all* untracked files not in .gitignore
@@ -126,7 +126,7 @@ git clean -fd
 ```
 
 # vgmstream123 player
-Should be buildable with Autotools, much like the Audicious plugin, though requires libao (libao-dev).
+Should be buildable with Autotools, much like the Audacious plugin, though requires libao (libao-dev).
 
 Windows builds aren't supported at the moment (source may need to be adapted for non-POSIX systems).
 

--- a/Makefile.autotools.am
+++ b/Makefile.autotools.am
@@ -1,7 +1,7 @@
-## audacious-vgmstream script
+## vgmstream autotools script
 ## Process this file with automake to produce Makefile.in
 
-AM_MAKEFLAGS=-f Makefile.audacious
+AM_MAKEFLAGS=-f Makefile.autotools
 
 SUBDIRS = src audacious test
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ or in a system directory, or any other directory in the PATH variable.
 ```
 Usage: test.exe [-o outfile.wav] [options] infile
 Options:
-    -o outfile.wav: name of output .wav file, default is dump.wav
+    -o outfile.wav: name of output .wav file, default is infile.wav
     -l loop count: loop count, default 2.0
     -f fade time: fade time (seconds), default 10.0
     -d fade delay: fade delay (seconds, default 0.0
@@ -57,6 +57,8 @@ Options:
 ```
 Typical usage would be: ```test -o happy.wav happy.adx``` to decode ```happy.adx``` to ```happy.wav```.
 
+Please follow the above instructions for installing the other files needed.
+
 ### in_vgmstream
 Drop the ```in_vgmstream.dll``` in your Winamp plugins directory. Please follow
 the above instructions for installing the other files needed.
@@ -76,10 +78,35 @@ and in the "priority filetypes" put: ```ahx,asf,awc,ckd,fsb,genh,msf,p3d,rak,scd
 Every file should be installed automatically by the .fb2k-component bundle.
 
 ### Audacious plugin
-Needs to be manually built. Instructions can be found in the build document.
+Needs to be manually built. Instructions can be found in the BUILD document.
 
 ### vgmstream123
-Needs to be manually built. Instructions can be found in the build document.
+Needs to be manually built. Instructions can be found in the BUILD document.
+
+```
+Usage: vgmstream123 [options] INFILE ...
+```
+
+The program is meant to be a simple stand-alone player, supporting playback
+of vgmstream files through libao. Files compressed with gzip/bzip2/xz also
+work, as identified by a .gz/.bz2/.xz extension. The file will be decompressed
+to a temp dir using the respective utility program (which must be installed
+and accessible) and then loaded.
+
+It also supports playlists, and will recognize a special extended-M3U tag
+specific to vgmstream of the following form:
+```
+#EXT-X-VGMSTREAM:LOOPCOUNT=2,FADETIME=10.0,FADEDELAY=0.0,STREAMINDEX=0
+```
+(Any subset of these four parameters may appear in the line, in any order)
+
+When this "magic comment" appears in the playlist before a vgmstream-compatible
+file, the given parameters will be applied to the playback of said file. This makes
+it feasible to play vgmstream files directly instead of needing to make "arranged"
+WAV/MP3 conversions ahead of time.
+
+The tag syntax follows the conventions established in Apple's HTTP Live Streaming
+standard, whose docs discuss extending M3U with arbitrary tags.
 
 ## Supported codec types
 Quick list of codecs vgmstream supports, including many obscure ones that 
@@ -95,7 +122,7 @@ are used in few games.
 - Nintendo AFC ADPCM
 - ITU-T G.721
 - CD-ROM XA ADPCM
-- Sony PSX ADPCM a.k.a VAG (badflags, bmdx, configurable)
+- Sony PSX ADPCM a.k.a VAG (standard, badflags, bmdx, configurable)
 - Sony HEVAG
 - Electronic Arts EA-XA (stereo, mono, Maxis)
 - Electronic Arts EA-XAS
@@ -125,6 +152,7 @@ are used in few games.
 - Electronic Arts EALayer3
 - Electronic Arts EA-XMA
 - Sony ATRAC3, ATRAC3plus
+- Sony ATRAC9
 - Microsoft XMA1/2
 - Microsoft WMA v1, WMA v2, WMAPro
 - AAC

--- a/audacious/Makefile.autotools.am
+++ b/audacious/Makefile.autotools.am
@@ -1,11 +1,11 @@
-## audacious-vgmstream automake script
+## vgmstream autotools script
 
 #inputplugindir = $(libdir)/audacious/$(INPUT_PLUGIN_DIR)
 inputplugindir = $(plugindir)/$(INPUT_PLUGIN_DIR)
 
 inputplugin_LTLIBRARIES = libvgmstream.la
 
-AM_MAKEFLAGS=-f Makefile.audacious
+AM_MAKEFLAGS=-f Makefile.autotools
 AM_CXXFLAGS = -DVERSION=\"VGMSTREAM_VERSION\" -Wall -std=c++11 -fpermissive -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/ $(AUDACIOUS_CFLAGS) $(GTK_CFLAGS)
 AM_LIBS =
 

--- a/bootstrap
+++ b/bootstrap
@@ -1,5 +1,5 @@
 #!/bin/sh
-# audacious-vgmstream script - automake/autoconf init
+# vgmstream autotools script - automake/autoconf init
 
 
 # gets all files and updates .am scripts to avoid having to do manually (frowned upon by automake, whatevs)
@@ -14,21 +14,21 @@ META_SRCS=`(cd ./src/meta/ && ls *.c) | tr '\n' ' '`
 META_HDRS=`(cd ./src/meta/ && ls *.h) | tr '\n' ' '`
 AUDACIOUS_SRCS=`(cd ./audacious/ && ls *.cc) | tr '\n' ' '`
 AUDACIOUS_HDRS=`(cd ./audacious/ && ls *.h) | tr '\n' ' '`
-sed -i -e "s/libvgmstream_la_SOURCES =.*/libvgmstream_la_SOURCES = $VGMSTREAM_SRCS/g" ./src/Makefile.audacious.am
-sed -i -e "s/EXTRA_DIST =.*/EXTRA_DIST = $VGMSTREAM_HDRS/g" ./src/Makefile.audacious.am
-sed -i -e "s/libcoding_la_SOURCES =.*/libcoding_la_SOURCES = $CODING_SRCS/g" ./src/coding/Makefile.audacious.am
-sed -i -e "s/EXTRA_DIST =.*/EXTRA_DIST = $CODING_HDRS/g" ./src/coding/Makefile.audacious.am
-sed -i -e "s/liblayout_la_SOURCES =.*/liblayout_la_SOURCES = $LAYOUT_SRCS/g" ./src/layout/Makefile.audacious.am
-sed -i -e "s/EXTRA_DIST =.*/EXTRA_DIST = $LAYOUT_HDRS/g" ./src/layout/Makefile.audacious.am
-sed -i -e "s/libmeta_la_SOURCES =.*/libmeta_la_SOURCES = $META_SRCS/g" ./src/meta/Makefile.audacious.am
-sed -i -e "s/EXTRA_DIST =.*/EXTRA_DIST = $META_HDRS/g" ./src/meta/Makefile.audacious.am
-sed -i -e "s/libvgmstream_la_SOURCES =.*/libvgmstream_la_SOURCES = $AUDACIOUS_SRCS/g" ./audacious/Makefile.audacious.am
-sed -i -e "s/EXTRA_DIST =.*/EXTRA_DIST = $AUDACIOUS_HDRS/g" ./audacious/Makefile.audacious.am
+sed -i -e "s/libvgmstream_la_SOURCES =.*/libvgmstream_la_SOURCES = $VGMSTREAM_SRCS/g" ./src/Makefile.autotools.am
+sed -i -e "s/EXTRA_DIST =.*/EXTRA_DIST = $VGMSTREAM_HDRS/g" ./src/Makefile.autotools.am
+sed -i -e "s/libcoding_la_SOURCES =.*/libcoding_la_SOURCES = $CODING_SRCS/g" ./src/coding/Makefile.autotools.am
+sed -i -e "s/EXTRA_DIST =.*/EXTRA_DIST = $CODING_HDRS/g" ./src/coding/Makefile.autotools.am
+sed -i -e "s/liblayout_la_SOURCES =.*/liblayout_la_SOURCES = $LAYOUT_SRCS/g" ./src/layout/Makefile.autotools.am
+sed -i -e "s/EXTRA_DIST =.*/EXTRA_DIST = $LAYOUT_HDRS/g" ./src/layout/Makefile.autotools.am
+sed -i -e "s/libmeta_la_SOURCES =.*/libmeta_la_SOURCES = $META_SRCS/g" ./src/meta/Makefile.autotools.am
+sed -i -e "s/EXTRA_DIST =.*/EXTRA_DIST = $META_HDRS/g" ./src/meta/Makefile.autotools.am
+sed -i -e "s/libvgmstream_la_SOURCES =.*/libvgmstream_la_SOURCES = $AUDACIOUS_SRCS/g" ./audacious/Makefile.autotools.am
+sed -i -e "s/EXTRA_DIST =.*/EXTRA_DIST = $AUDACIOUS_HDRS/g" ./audacious/Makefile.autotools.am
 
 # get version to show in about dialogs
 # again, not very pretty
 VGMSTREAM_VERSION=`./version.sh`
-sed -i -e "s/VGMSTREAM_VERSION/$VGMSTREAM_VERSION/g" ./audacious/Makefile.audacious.am
+sed -i -e "s/VGMSTREAM_VERSION/$VGMSTREAM_VERSION/g" ./audacious/Makefile.autotools.am
 
 
 # create fake files expected by automake and process

--- a/configure.ac
+++ b/configure.ac
@@ -60,11 +60,11 @@ AC_PATH_X
 AC_PATH_XTRA
 
 AC_OUTPUT([
-  Makefile.audacious
-  src/Makefile.audacious
-  src/coding/Makefile.audacious
-  src/layout/Makefile.audacious
-  src/meta/Makefile.audacious
-  audacious/Makefile.audacious
-  test/Makefile.audacious
+  Makefile.autotools
+  src/Makefile.autotools
+  src/coding/Makefile.autotools
+  src/layout/Makefile.autotools
+  src/meta/Makefile.autotools
+  audacious/Makefile.autotools
+  test/Makefile.autotools
 ])

--- a/src/Makefile.autotools.am
+++ b/src/Makefile.autotools.am
@@ -1,9 +1,9 @@
-## audacious-vgmstream automake script
+## vgmstream autotools script
 
 lib_LTLIBRARIES = libvgmstream.la
 
 AM_CFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
-AM_MAKEFLAGS=-f Makefile.audacious
+AM_MAKEFLAGS=-f Makefile.autotools
 
 SUBDIRS = coding layout meta
 

--- a/src/coding/Makefile.autotools.am
+++ b/src/coding/Makefile.autotools.am
@@ -1,11 +1,11 @@
-## audacious-vgmstream automake script
+## vgmstream autotools script
 
-noinst_LTLIBRARIES = liblayout.la
+noinst_LTLIBRARIES = libcoding.la
 
 AM_CFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
-AM_MAKEFLAGS=-f Makefile.audacious
+AM_MAKEFLAGS=-f Makefile.autotools
 
 # sources/headers are updated automatically by ./bootstrap script (not all headers are needed though)
-liblayout_la_LDFLAGS =
-liblayout_la_SOURCES = (auto-updated)
+libcoding_la_LDFLAGS =
+libcoding_la_SOURCES = (auto-updated)
 EXTRA_DIST = (auto-updated)

--- a/src/coding/atrac9_decoder.c
+++ b/src/coding/atrac9_decoder.c
@@ -1,0 +1,219 @@
+#include "coding.h"
+
+#ifdef VGM_USE_ATRAC9
+#include "libatrac9.h"
+
+
+atrac9_codec_data *init_atrac9(atrac9_config *cfg) {
+    int status;
+    uint8_t config_data[4];
+    Atrac9CodecInfo info = {0};
+    atrac9_codec_data *data = NULL;
+
+    data = calloc(1, sizeof(atrac9_codec_data));
+
+    data->handle = Atrac9GetHandle();
+    if (!data->handle) goto fail;
+
+    put_32bitBE(config_data, cfg->config_data);
+    status = Atrac9InitDecoder(data->handle, config_data);
+    if (status < 0) goto fail;
+
+    status = Atrac9GetCodecInfo(data->handle, &info);
+    if (status < 0) goto fail;
+    //;VGM_LOG("ATRAC9: config=%x, sf-size=%x, sub-frames=%i x %i samples\n", cfg->config_data, info.superframeSize, info.framesInSuperframe, info.frameSamples);
+
+    if (cfg->channels && cfg->channels != info.channels) {
+        VGM_LOG("ATRAC9: channels in header %i vs config %i don't match\n", cfg->channels, info.channels);
+        goto fail; /* unknown multichannel layout */
+    }
+
+
+    /* must hold at least one superframe and its samples */
+    data->data_buffer_size = info.superframeSize;
+    data->data_buffer = calloc(sizeof(uint8_t), data->data_buffer_size);
+    data->sample_buffer = calloc(sizeof(sample), info.channels * info.frameSamples * info.framesInSuperframe);
+
+    data->samples_to_discard = cfg->encoder_delay;
+
+    memcpy(&data->config, cfg, sizeof(atrac9_config));
+
+    return data;
+
+fail:
+    return NULL;
+}
+
+void decode_atrac9(VGMSTREAM *vgmstream, sample * outbuf, int32_t samples_to_do, int channels) {
+    VGMSTREAMCHANNEL *stream = &vgmstream->ch[0];
+    atrac9_codec_data * data = vgmstream->codec_data;
+    int samples_done = 0;
+
+
+    while (samples_done < samples_to_do) {
+
+        if (data->samples_filled) {  /* consume samples */
+            int samples_to_get = data->samples_filled;
+
+            if (data->samples_to_discard) {
+                /* discard samples for looping */
+                if (samples_to_get > data->samples_to_discard)
+                    samples_to_get = data->samples_to_discard;
+                data->samples_to_discard -= samples_to_get;
+            }
+            else {
+                /* get max samples and copy */
+                if (samples_to_get > samples_to_do - samples_done)
+                    samples_to_get = samples_to_do - samples_done;
+
+                memcpy(outbuf + samples_done*channels,
+                       data->sample_buffer + data->samples_used*channels,
+                       samples_to_get*channels * sizeof(sample));
+
+                samples_done += samples_to_get;
+            }
+
+            /* mark consumed samples */
+            data->samples_used += samples_to_get;
+            data->samples_filled -= samples_to_get;
+        }
+        else { /* decode data */
+            int iframe, status;
+            int bytes_used = 0;
+            uint8_t *buffer = data->data_buffer;
+            size_t bytes;
+            Atrac9CodecInfo info = {0};
+
+            data->samples_used = 0;
+
+            /* ATRAC9 is made of decodable superframes with several sub-frames. AT9 config data gives
+             * superframe size, number of frames and samples (~100-200 bytes and ~256/1024 samples). */
+            status = Atrac9GetCodecInfo(data->handle, &info);
+            if (status < 0) goto decode_fail;
+
+
+            /* preadjust */ //todo improve
+            switch(data->config.type) {
+                case ATRAC9_XVAG:
+                    /* PS4 (ex. The Last of Us) has a RIFF AT9 (can be ignored) instead of the first superframe.
+                     * As subsongs do too, needs to be skipped here instead of adjusting start_offset */
+                    if (stream->offset == stream->channel_start_offset) {
+                        if (read_32bitBE(stream->offset, stream->streamfile) == 0x00000000  /* padding before RIFF */
+                                && read_32bitBE(stream->offset + info.superframeSize - 0x08,stream->streamfile) == 0x64617461) { /* RIFF's "data" */
+                            stream->offset += info.superframeSize;
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            /* read one raw block (superframe) and advance offsets */
+            bytes = read_streamfile(data->data_buffer,stream->offset, info.superframeSize,stream->streamfile);
+            if (bytes != data->data_buffer_size) {
+                VGM_LOG("ATRAC9: read %x vs expected %x bytes  at %lx\n", bytes, info.superframeSize, stream->offset);
+                goto decode_fail;
+            }
+
+            stream->offset += bytes;
+
+            /* postadjust */ //todo improve
+            switch(data->config.type) {
+                case ATRAC9_XVAG: /* skip other subsong blocks in XVAG */
+                    if (data->config.interleave_skip && ((stream->offset - stream->channel_start_offset) % data->config.interleave_skip == 0)) {
+                        stream->offset += data->config.interleave_skip * (data->config.subsong_skip - 1);
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+
+            /* decode all frames in the superframe block */
+            for (iframe = 0; iframe < info.framesInSuperframe; iframe++) {
+                status = Atrac9Decode(data->handle, buffer, data->sample_buffer + data->samples_filled*channels, &bytes_used);
+                if (status < 0) goto decode_fail;
+
+                buffer += bytes_used;
+                data->samples_filled += info.frameSamples;
+            }
+        }
+    }
+
+    return;
+
+decode_fail:
+    /* on error just put some 0 samples */
+    VGM_LOG("ATRAC9: decode fail at %lx, missing %i samples\n", stream->offset, (samples_to_do - samples_done));
+    memset(outbuf + samples_done * channels, 0, (samples_to_do - samples_done) * sizeof(sample) * channels);
+}
+
+void reset_atrac9(VGMSTREAM *vgmstream) {
+    atrac9_codec_data *data = vgmstream->codec_data;
+
+    if (!data->handle)
+        goto fail;
+
+#if 0
+    /* reopen/flush, not needed as superframes decode separatedly and there is no carried state */
+    {
+        int status;
+        uint8_t config_data[4];
+
+        Atrac9ReleaseHandle(data->handle);
+        data->handle = Atrac9GetHandle();
+        if (!data->handle) goto fail;
+
+        put_32bitBE(config_data, data->config.config_data);
+        status = Atrac9InitDecoder(data->handle, config_data);
+        if (status < 0) goto fail;
+    }
+#endif
+
+    data->samples_used = 0;
+    data->samples_filled = 0;
+    data->samples_to_discard = 0;
+
+    return;
+
+fail:
+    return; /* decode calls should fail... */
+}
+
+void seek_atrac9(VGMSTREAM *vgmstream, int32_t num_sample) {
+    atrac9_codec_data *data = vgmstream->codec_data;
+
+    reset_atrac9(vgmstream);
+
+    data->samples_to_discard = num_sample;
+    data->samples_to_discard += data->config.encoder_delay;
+
+    /* loop offsets are set during decode; force them to stream start so discard works */
+    if (vgmstream->loop_ch)
+        vgmstream->loop_ch[0].offset = vgmstream->loop_ch[0].channel_start_offset;
+}
+
+void free_atrac9(atrac9_codec_data *data) {
+    if (!data)
+        return;
+
+    if (data->handle) Atrac9ReleaseHandle(data->handle);
+    free(data->data_buffer);
+    free(data->sample_buffer);
+    free(data);
+}
+
+
+size_t atrac9_bytes_to_samples(size_t bytes, atrac9_codec_data *data) {
+    Atrac9CodecInfo info = {0};
+    int status;
+
+    status = Atrac9GetCodecInfo(data->handle, &info);
+    if (status < 0) goto fail;
+
+    return bytes / info.superframeSize * (info.frameSamples * info.framesInSuperframe);
+
+fail:
+    return 0;
+}
+#endif

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -80,7 +80,6 @@ size_t ps_bytes_to_samples(size_t bytes, int channels);
 
 /* xa_decoder */
 void decode_xa(VGMSTREAM * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel);
-void xa_init_get_high_nibble(VGMSTREAM * vgmstream);
 size_t xa_bytes_to_samples(size_t bytes, int channels, int is_blocked);
 
 /* ea_xa_decoder */

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -158,7 +158,7 @@ void seek_ogg_vorbis(VGMSTREAM *vgmstream, int32_t num_sample);
 void free_ogg_vorbis(ogg_vorbis_codec_data *data);
 
 /* vorbis_custom_decoder */
-vorbis_custom_codec_data * init_vorbis_custom_codec_data(STREAMFILE *streamfile, off_t start_offset, vorbis_custom_t type, vorbis_custom_config * config);
+vorbis_custom_codec_data *init_vorbis_custom(STREAMFILE *streamfile, off_t start_offset, vorbis_custom_t type, vorbis_custom_config * config);
 void decode_vorbis_custom(VGMSTREAM * vgmstream, sample * outbuf, int32_t samples_to_do, int channels);
 void reset_vorbis_custom(VGMSTREAM *vgmstream);
 void seek_vorbis_custom(VGMSTREAM *vgmstream, int32_t num_sample);
@@ -167,11 +167,9 @@ void free_vorbis_custom(vorbis_custom_codec_data *data);
 
 #ifdef VGM_USE_MPEG
 /* mpeg_decoder */
-mpeg_codec_data *init_mpeg_codec_data(STREAMFILE *streamfile, off_t start_offset, coding_t *coding_type, int channels);
-mpeg_codec_data *init_mpeg_custom_codec_data(STREAMFILE *streamFile, off_t start_offset, coding_t *coding_type, int channels, mpeg_custom_t custom_type, mpeg_custom_config *config);
-
+mpeg_codec_data *init_mpeg(STREAMFILE *streamfile, off_t start_offset, coding_t *coding_type, int channels);
+mpeg_codec_data *init_mpeg_custom(STREAMFILE *streamFile, off_t start_offset, coding_t *coding_type, int channels, mpeg_custom_t custom_type, mpeg_custom_config *config);
 void decode_mpeg(VGMSTREAM * vgmstream, sample * outbuf, int32_t samples_to_do, int channels);
-void decode_fake_mpeg2_l2(VGMSTREAMCHANNEL * stream, mpeg_codec_data * data, sample * outbuf, int32_t samples_to_do);
 void reset_mpeg(VGMSTREAM *vgmstream);
 void seek_mpeg(VGMSTREAM *vgmstream, int32_t num_sample);
 void free_mpeg(mpeg_codec_data *data);
@@ -225,9 +223,9 @@ size_t atrac9_bytes_to_samples(size_t bytes, atrac9_codec_data *data);
 
 #ifdef VGM_USE_FFMPEG
 /* ffmpeg_decoder */
-ffmpeg_codec_data * init_ffmpeg_offset(STREAMFILE *streamFile, uint64_t start, uint64_t size);
-ffmpeg_codec_data * init_ffmpeg_header_offset(STREAMFILE *streamFile, uint8_t * header, uint64_t header_size, uint64_t start, uint64_t size);
-ffmpeg_codec_data * init_ffmpeg_config(STREAMFILE *streamFile, uint8_t * header, uint64_t header_size, uint64_t start, uint64_t size, ffmpeg_custom_config * config);
+ffmpeg_codec_data *init_ffmpeg_offset(STREAMFILE *streamFile, uint64_t start, uint64_t size);
+ffmpeg_codec_data *init_ffmpeg_header_offset(STREAMFILE *streamFile, uint8_t * header, uint64_t header_size, uint64_t start, uint64_t size);
+ffmpeg_codec_data *init_ffmpeg_config(STREAMFILE *streamFile, uint8_t * header, uint64_t header_size, uint64_t start, uint64_t size, ffmpeg_custom_config * config);
 
 void decode_ffmpeg(VGMSTREAM *stream, sample * outbuf, int32_t samples_to_do, int channels);
 void reset_ffmpeg(VGMSTREAM *vgmstream);

--- a/src/coding/mpeg_decoder.c
+++ b/src/coding/mpeg_decoder.c
@@ -22,7 +22,7 @@ static void decode_mpeg_custom_stream(VGMSTREAMCHANNEL *stream, mpeg_codec_data 
 
 
 /* Inits regular MPEG */
-mpeg_codec_data *init_mpeg_codec_data(STREAMFILE *streamfile, off_t start_offset, coding_t *coding_type, int channels) {
+mpeg_codec_data *init_mpeg(STREAMFILE *streamfile, off_t start_offset, coding_t *coding_type, int channels) {
     mpeg_codec_data *data = NULL;
 
     /* init codec */
@@ -117,7 +117,7 @@ fail:
 
 
 /* Init custom MPEG, with given type and config */
-mpeg_codec_data *init_mpeg_custom_codec_data(STREAMFILE *streamFile, off_t start_offset, coding_t *coding_type, int channels, mpeg_custom_t type, mpeg_custom_config *config) {
+mpeg_codec_data *init_mpeg_custom(STREAMFILE *streamFile, off_t start_offset, coding_t *coding_type, int channels, mpeg_custom_t type, mpeg_custom_config *config) {
     mpeg_codec_data *data = NULL;
     int i, ok;
 

--- a/src/coding/psx_decoder.c
+++ b/src/coding/psx_decoder.c
@@ -6,12 +6,25 @@
 #define VAG_USE_INTEGER_TABLE   0
 
 /* PS ADPCM table (precalculated divs) */
-static const double VAG_f[5][2] = {
+static const double VAG_f[16][2] = {
         {   0.0        ,   0.0        },
         {  60.0 / 64.0 ,   0.0        },
         { 115.0 / 64.0 , -52.0 / 64.0 },
         {  98.0 / 64.0 , -55.0 / 64.0 },
-        { 122.0 / 64.0 , -60.0 / 64.0 }
+        { 122.0 / 64.0 , -60.0 / 64.0 },
+        /* extended table from PPSSPP (PSP emu), found by tests
+         * (only seen in inFamous PS3, very rare, possibly "SVAG" or "VAG-HE") */
+        {   0.0        ,   0.0        },
+        {   0.0        ,   0.0        },
+        {  52.0 / 64.0 ,   0.0        },
+        {  55.0 / 64.0 ,  -2.0 / 64.0 },
+        {  60.0 / 64.0 ,-125.0 / 64.0 },
+        {   0.0        ,   0.0        },
+        {   0.0        , -91.0 / 64.0 },
+        {   0.0        ,   0.0        },
+        {   2.0 / 64.0 ,-216.0 / 64.0 },
+        { 125.0 / 64.0 ,  -6.0 / 64.0 },
+        {   0.0        ,-151.0 / 64.0 },
 };
 #if VAG_USE_INTEGER_TABLE
 /* PS ADPCM table */
@@ -20,7 +33,19 @@ static const int8_t VAG_coefs[5][2] = {
         {  60 ,   0 },
         { 115 , -52 },
         {  98 , -55 },
-        { 122 , -60 }
+        { 122 , -60 },
+        /* extended */
+        {   0 ,   0 },
+        {   0 ,   0 },
+        {  52 ,   0 },
+        {  55 ,  -2 },
+        {  60 ,-125 },
+        {   0 ,   0 },
+        {   0 , -91 },
+        {   0 ,   0 },
+        {   2 ,-216 },
+        { 125 ,  -6 },
+        {   0 ,-151 },
 };
 #endif
 

--- a/src/coding/vorbis_custom_decoder.c
+++ b/src/coding/vorbis_custom_decoder.c
@@ -19,7 +19,7 @@ static void pcm_convert_float_to_16(vorbis_custom_codec_data * data, sample * ou
  *
  * Reference: https://www.xiph.org/vorbis/doc/libvorbis/overview.html
  */
-vorbis_custom_codec_data * init_vorbis_custom_codec_data(STREAMFILE *streamFile, off_t start_offset, vorbis_custom_t type, vorbis_custom_config * config) {
+vorbis_custom_codec_data * init_vorbis_custom(STREAMFILE *streamFile, off_t start_offset, vorbis_custom_t type, vorbis_custom_config * config) {
     vorbis_custom_codec_data * data = NULL;
     int ok;
 

--- a/src/coding/xa_decoder.c
+++ b/src/coding/xa_decoder.c
@@ -20,10 +20,6 @@ static int CLAMP(int value, int Minim, int Maxim)
     return value;
 }
 
-void xa_init_get_high_nibble(VGMSTREAM *vgmstream) {
-	vgmstream->xa_get_high_nibble=1;
-}
-
 void decode_xa(VGMSTREAM * vgmstream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int channel) {
 
     VGMSTREAMCHANNEL * stream = &(vgmstream->ch[channel]);

--- a/src/formats.c
+++ b/src/formats.c
@@ -107,7 +107,7 @@ static const char* extension_list[] = {
     "emff",
     "enth",
     "exa",
-	"ezw",
+    "ezw",
 
     "fag",
     "ffw",
@@ -184,7 +184,7 @@ static const char* extension_list[] = {
     "mic",
     "mihb",
     "mnstr",
-	"mogg",
+    "mogg",
     //"mp4", //common
     //"mpc", //FFmpeg, not parsed (musepack) //common
     "mpdsp",
@@ -932,8 +932,7 @@ static const meta_info meta_info_list[] = {
         {meta_EA_SPS,               "Electronic Arts SPS header"},
         {meta_NGC_VID1,             "Neversoft VID1 header"},
         {meta_PC_FLX,               "Ultima IX .FLX header"},
-		{meta_MOGG,                 "Harmonix Music Systems MOGG Vorbis "},
-
+        {meta_MOGG,                 "Harmonix Music Systems MOGG Vorbis"},
 
 #ifdef VGM_USE_VORBIS
         {meta_OGG_VORBIS,           "Ogg Vorbis"},

--- a/src/formats.c
+++ b/src/formats.c
@@ -158,6 +158,7 @@ static const char* extension_list[] = {
     "kovs",
     "kraw",
     "ktss",
+    "kvs",
 
     "laac", //fake extension, for AAC (tri-Ace/FFmpeg)
     "lac3", //fake extension, for AC3

--- a/src/formats.c
+++ b/src/formats.c
@@ -42,6 +42,7 @@ static const char* extension_list[] = {
     "ass",
     "ast",
     "at3",
+    "at9",
     "aud",
     "aus",
     "awc",

--- a/src/layout/Makefile.autotools.am
+++ b/src/layout/Makefile.autotools.am
@@ -1,11 +1,11 @@
-## audacious-vgmstream automake script
+## vgmstream autotools script
 
-noinst_LTLIBRARIES = libcoding.la
+noinst_LTLIBRARIES = liblayout.la
 
 AM_CFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
-AM_MAKEFLAGS=-f Makefile.audacious
+AM_MAKEFLAGS=-f Makefile.autotools
 
 # sources/headers are updated automatically by ./bootstrap script (not all headers are needed though)
-libcoding_la_LDFLAGS =
-libcoding_la_SOURCES = (auto-updated)
+liblayout_la_LDFLAGS =
+liblayout_la_SOURCES = (auto-updated)
 EXTRA_DIST = (auto-updated)

--- a/src/layout/xa_blocked.c
+++ b/src/layout/xa_blocked.c
@@ -8,13 +8,13 @@ void xa_block_update(off_t block_offset, VGMSTREAM * vgmstream) {
     int8_t currentChannel=0;
     int8_t subAudio=0;
 
-    xa_init_get_high_nibble(vgmstream);
+    vgmstream->xa_get_high_nibble = 1; /* reset nibble order */
 
     /* don't change this variable in the init process */
     if (vgmstream->samples_into_block != 0)
         vgmstream->xa_sector_length += 0x80;
 
-    /* XA mode2/form2 sector
+    /* XA mode2/form2 sector, size 0x930
      * 0x00: sync word
      * 0x0c: header = minute, second, sector, mode (always 0x02)
      * 0x10: subheader = file, channel (marker), submode flags, xa header
@@ -23,9 +23,10 @@ void xa_block_update(off_t block_offset, VGMSTREAM * vgmstream) {
      * 0x918: unused
      * 0x92c: EDC/checksum or null
      * 0x930: end
+     * (in non-blocked ISO 2048 mode1/data chunks are 0x800)
      */
 
-    /* submode flags (typical audio value = 0x64)
+    /* submode flag bits (typical audio value = 0x64)
      * - 7: end of file
      * - 6: real time mode
      * - 5: sector form (0=form1, 1=form2)

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -134,6 +134,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="coding\at3plus_decoder.c" />
+    <ClCompile Include="coding\atrac9_decoder.c" />
     <ClCompile Include="coding\coding_utils.c" />
     <ClCompile Include="coding\ffmpeg_decoder.c" />
     <ClCompile Include="coding\ffmpeg_decoder_utils_bgw_atrac3.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1174,6 +1174,9 @@
     <ClCompile Include="coding\at3plus_decoder.c">
       <Filter>coding\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="coding\atrac9_decoder.c">
+      <Filter>coding\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\bcstm.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/meta/Makefile.autotools.am
+++ b/src/meta/Makefile.autotools.am
@@ -1,9 +1,9 @@
-## audacious-vgmstream automake script
+## vgmstream autotools script
 
 noinst_LTLIBRARIES = libmeta.la
 
 AM_CFLAGS = -DVAR_ARRAYS -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/
-AM_MAKEFLAGS=-f Makefile.audacious
+AM_MAKEFLAGS=-f Makefile.autotools
 
 # sources/headers are updated automatically by ./bootstrap script (not all headers are needed though)
 libmeta_la_LDFLAGS =

--- a/src/meta/ahx.c
+++ b/src/meta/ahx.c
@@ -64,7 +64,7 @@ VGMSTREAM * init_vgmstream_ahx(STREAMFILE *streamFile) {
         }
 
         vgmstream->layout_type = layout_none;
-        vgmstream->codec_data = init_mpeg_custom_codec_data(streamFile, start_offset, &vgmstream->coding_type, channel_count, MPEG_AHX, &cfg);
+        vgmstream->codec_data = init_mpeg_custom(streamFile, start_offset, &vgmstream->coding_type, channel_count, MPEG_AHX, &cfg);
         if (!vgmstream->codec_data) goto fail;
 #else
         goto fail;

--- a/src/meta/awc.c
+++ b/src/meta/awc.c
@@ -74,7 +74,7 @@ VGMSTREAM * init_vgmstream_awc(STREAMFILE *streamFile) {
             cfg.chunk_size = awc.block_chunk;
             cfg.big_endian = awc.big_endian;
 
-            vgmstream->codec_data = init_mpeg_custom_codec_data(streamFile, awc.stream_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_AWC, &cfg);
+            vgmstream->codec_data = init_mpeg_custom(streamFile, awc.stream_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_AWC, &cfg);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->layout_type = layout_none;
 

--- a/src/meta/ea_eaac.c
+++ b/src/meta/ea_eaac.c
@@ -214,7 +214,7 @@ static VGMSTREAM * init_vgmstream_eaaudiocore_header(STREAMFILE * streamHead, ST
             mpeg_custom_t type = (codec == 0x05 ? MPEG_EAL31b : (codec == 0x06) ? MPEG_EAL32P : MPEG_EAL32S);
 
             /* layout is still blocks, but should work fine with the custom mpeg decoder */
-            vgmstream->codec_data = init_mpeg_custom_codec_data(streamData, mpeg_start_offset, &vgmstream->coding_type, vgmstream->channels, type, &cfg);
+            vgmstream->codec_data = init_mpeg_custom(streamData, mpeg_start_offset, &vgmstream->coding_type, vgmstream->channels, type, &cfg);
             if (!vgmstream->codec_data) goto fail;
 
             vgmstream->layout_type = layout_blocked_ea_sns;

--- a/src/meta/ea_schl.c
+++ b/src/meta/ea_schl.c
@@ -320,7 +320,7 @@ static VGMSTREAM * init_vgmstream_ea_variable_header(STREAMFILE *streamFile, ea_
             if (!mpeg_start_offset) goto fail;
 
             /* layout is still blocks, but should work fine with the custom mpeg decoder */
-            vgmstream->codec_data = init_mpeg_custom_codec_data(streamFile, mpeg_start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_EA, &cfg);
+            vgmstream->codec_data = init_mpeg_custom(streamFile, mpeg_start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_EA, &cfg);
             if (!vgmstream->codec_data) goto fail;
             break;
         }
@@ -333,7 +333,7 @@ static VGMSTREAM * init_vgmstream_ea_variable_header(STREAMFILE *streamFile, ea_
             if (!mpeg_start_offset) goto fail;
 
             /* layout is still blocks, but should work fine with the custom mpeg decoder */
-            vgmstream->codec_data = init_mpeg_custom_codec_data(streamFile, mpeg_start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_EAL31, &cfg);
+            vgmstream->codec_data = init_mpeg_custom(streamFile, mpeg_start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_EAL31, &cfg);
             if (!vgmstream->codec_data) goto fail;
             break;
         }

--- a/src/meta/fsb.c
+++ b/src/meta/fsb.c
@@ -296,7 +296,7 @@ VGMSTREAM * init_vgmstream_fsb_offset(STREAMFILE *streamFile, off_t offset) {
         //VGM_ASSERT(fsbh.mode & FSOUND_MPEG_LAYER2, "FSB FSOUND_MPEG_LAYER2 found\n");/* not always set anyway */
         VGM_ASSERT(fsbh.mode & FSOUND_IGNORETAGS, "FSB FSOUND_IGNORETAGS found\n");
 
-        vgmstream->codec_data = init_mpeg_custom_codec_data(streamFile, start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_FSB, &cfg);
+        vgmstream->codec_data = init_mpeg_custom(streamFile, start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_FSB, &cfg);
         if (!vgmstream->codec_data) goto fail;
         vgmstream->layout_type = layout_none;
 

--- a/src/meta/fsb5.c
+++ b/src/meta/fsb5.c
@@ -7,34 +7,40 @@ VGMSTREAM * init_vgmstream_fsb5(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
     off_t StartOffset = 0, NameOffset = 0;
     off_t SampleHeaderStart = 0, ExtraInfoStart = 0;
-    size_t SampleHeaderLength, NameTableLength, SampleDataLength, BaseHeaderLength, StreamSize = 0;
+    size_t SampleHeaderLength, NameTableLength, SampleDataLength, BaseHeaderLength, StreamSize = 0, ExtraInfoSize = 0;
 
     uint32_t NumSamples = 0, LoopStart = 0, LoopEnd = 0;
-    int LoopFlag = 0, ChannelCount = 0, SampleRate = 0, CodingID;
+    int LoopFlag = 0, ChannelCount = 0, Version, SampleRate = 0, CodingID;
     int TotalStreams, TargetStream = streamFile->stream_index;
     int i;
 
     /* check extension, case insensitive */
-    if (!check_extensions(streamFile,"fsb")) goto fail;
+    if (!check_extensions(streamFile,"fsb"))
+        goto fail;
 
-    if (read_32bitBE(0x00,streamFile) != 0x46534235) goto fail; /* "FSB5" */
+    if (read_32bitBE(0x00,streamFile) != 0x46534235) /* "FSB5" */
+        goto fail;
 
-    //v0 has extra flags at 0x1c and BaseHeaderLength = 0x40?
-    if (read_32bitLE(0x04,streamFile) != 0x01) goto fail; /* Version ID */
+    /* 0x00 is rare (seen in Tales from Space Vita) */
+    Version = read_32bitLE(0x04,streamFile);
+    if (Version != 0x00 && Version != 0x01) goto fail;
 
     TotalStreams       = read_32bitLE(0x08,streamFile);
     SampleHeaderLength = read_32bitLE(0x0C,streamFile);
     NameTableLength    = read_32bitLE(0x10,streamFile);
     SampleDataLength   = read_32bitLE(0x14,streamFile);
     CodingID = read_32bitLE(0x18,streamFile);
-    /* 0x1c (8): zero,  0x24 (16): hash,  0x34 (8): unk  */
-    BaseHeaderLength = 0x3C;
+    /* type 0x01 - 0x1c(8): zero,  0x24(16): hash,  0x34(8): unk
+     * type 0x00 has an extra field (always 0?) at 0x1c */
+    BaseHeaderLength = (Version==0x00) ? 0x40 : 0x3C;
 
-    SampleHeaderStart = BaseHeaderLength;
+    if ((SampleHeaderLength + NameTableLength + SampleDataLength + BaseHeaderLength) != get_streamfile_size(streamFile))
+        goto fail;
 
-    if ((SampleHeaderLength + NameTableLength + SampleDataLength + 0x3C) != get_streamfile_size(streamFile)) goto fail;
     if (TargetStream == 0) TargetStream = 1; /* default to 1 */
     if (TargetStream > TotalStreams || TotalStreams <= 0) goto fail;
+
+    SampleHeaderStart = BaseHeaderLength;
 
     /* find target stream header and data offset, and read all needed values for later use
      *  (reads one by one as the size of a single stream header is variable) */
@@ -112,6 +118,9 @@ VGMSTREAM * init_vgmstream_fsb5(STREAMFILE *streamFile) {
                         break;
                     case 0x04:  /* free comment, or maybe SFX info */
                         break;
+                    //case 0x05:  /* Unknown (32b) */
+                    //    /* found in Tearaway Vita, value 0, first stream only  */
+                    //    break;
                     case 0x06:  /* XMA seek table */
                         /* no need for it */
                         break;
@@ -120,6 +129,7 @@ VGMSTREAM * init_vgmstream_fsb5(STREAMFILE *streamFile) {
                         break;
                     case 0x09:  /* ATRAC9 config */
                         ExtraInfoStart = ExtraFlagStart + 0x04;
+                        ExtraInfoSize = ExtraFlagSize;
                         break;
                     case 0x0a:  /* XWMA data */
                         break;
@@ -132,7 +142,8 @@ VGMSTREAM * init_vgmstream_fsb5(STREAMFILE *streamFile) {
                          * (xN entries)
                          */
                         break;
-                    //case 0x0d:  /* Unknown value (32b), found in some XMA2 and Vorbis */
+                    //case 0x0d:  /* Unknown (32b) */
+                    //    /* found in some XMA2 and Vorbis */
                     //    break;
                     default:
                         VGM_LOG("FSB5: unknown extra flag 0x%x at 0x%04x (size 0x%x)\n", ExtraFlagType, ExtraFlagStart, ExtraFlagSize);
@@ -277,7 +288,23 @@ VGMSTREAM * init_vgmstream_fsb5(STREAMFILE *streamFile) {
             atrac9_config cfg = {0};
 
             cfg.channels = vgmstream->channels;
-            cfg.config_data = read_32bitBE(ExtraInfoStart,streamFile);
+            switch(ExtraInfoSize) {
+                case 0x04: /* Little Big Planet 2ch (Vita), Guacamelee (Vita) */
+                    cfg.config_data = read_32bitBE(ExtraInfoStart,streamFile);
+                    break;
+                case 0x08: /* Day of the Tentacle Remastered (Vita) */
+                    /* 0x00: superframe size (also in config_data) */
+                    cfg.config_data = read_32bitBE(ExtraInfoStart+0x04,streamFile);
+                    break;
+                //case 0x0c: /* Little Big Planet 6ch (Vita) */
+                //    //todo: this is just 0x04 x3, in case of 4ch would be 0x08 --must improve detection
+                //    //each stream has its own config_data (but seem to be the same), interleaves 1 super frame per stream
+                //    break;
+                default:
+                    VGM_LOG("FSB5: unknown extra info size 0x%x\n", ExtraInfoSize);
+                    goto fail;
+            }
+            //cfg.encoder_delay = 0x100; //todo not used? num_samples seems to count all data
 
             vgmstream->codec_data = init_atrac9(&cfg);
             if (!vgmstream->codec_data) goto fail;

--- a/src/meta/fsb5.c
+++ b/src/meta/fsb5.c
@@ -274,7 +274,7 @@ VGMSTREAM * init_vgmstream_fsb5(STREAMFILE *streamFile) {
 
             cfg.fsb_padding = (vgmstream->channels > 2 ? 16 : 4); /* observed default */
 
-            vgmstream->codec_data = init_mpeg_custom_codec_data(streamFile, StartOffset, &vgmstream->coding_type, vgmstream->channels, MPEG_FSB, &cfg);
+            vgmstream->codec_data = init_mpeg_custom(streamFile, StartOffset, &vgmstream->coding_type, vgmstream->channels, MPEG_FSB, &cfg);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->layout_type = layout_none;
             break;
@@ -327,7 +327,7 @@ VGMSTREAM * init_vgmstream_fsb5(STREAMFILE *streamFile) {
 
             vgmstream->layout_type = layout_none;
             vgmstream->coding_type = coding_VORBIS_custom;
-            vgmstream->codec_data = init_vorbis_custom_codec_data(streamFile, StartOffset, VORBIS_FSB, &cfg);
+            vgmstream->codec_data = init_vorbis_custom(streamFile, StartOffset, VORBIS_FSB, &cfg);
             if (!vgmstream->codec_data) goto fail;
 
             break;

--- a/src/meta/genh.c
+++ b/src/meta/genh.c
@@ -239,7 +239,7 @@ VGMSTREAM * init_vgmstream_genh(STREAMFILE *streamFile) {
 #ifdef VGM_USE_MPEG
         case coding_MPEG_layer3:
             vgmstream->layout_type = layout_none;
-            vgmstream->codec_data = init_mpeg_codec_data(streamFile, genh.start_offset, &coding, vgmstream->channels);
+            vgmstream->codec_data = init_mpeg(streamFile, genh.start_offset, &coding, vgmstream->channels);
             if (!vgmstream->codec_data) goto fail;
 
             break;

--- a/src/meta/ngc_vid1.c
+++ b/src/meta/ngc_vid1.c
@@ -57,7 +57,7 @@ VGMSTREAM * init_vgmstream_ngc_vid1(STREAMFILE *streamFile) {
 
         vgmstream->layout_type = layout_none;
         vgmstream->coding_type = coding_VORBIS_custom;
-        vgmstream->codec_data = init_vorbis_custom_codec_data(streamFile, header_offset + 0x20, VORBIS_VID1, &cfg);
+        vgmstream->codec_data = init_vorbis_custom(streamFile, header_offset + 0x20, VORBIS_VID1, &cfg);
         if (!vgmstream->codec_data) goto fail;
     }
 #else

--- a/src/meta/ogg_vorbis_file.c
+++ b/src/meta/ogg_vorbis_file.c
@@ -189,7 +189,7 @@ VGMSTREAM * init_vgmstream_ogg_vorbis(STREAMFILE *streamFile) {
             strcasecmp("ogg",filename_extension(filename))) {
         if (!strcasecmp("um3",filename_extension(filename))) {
             um3_ogg = 1;
-        } else if (!strcasecmp("kovs",filename_extension(filename))) {
+        } else if (check_extensions(streamFile,"kvs,kovs")) { /* .kvs: Atelier Sophie, kovs: header id only? */
             kovs_ogg = 1;
         } else {
             goto fail;

--- a/src/meta/ogl.c
+++ b/src/meta/ogl.c
@@ -46,7 +46,7 @@ VGMSTREAM * init_vgmstream_ogl(STREAMFILE *streamFile) {
 
         vgmstream->layout_type = layout_none;
         vgmstream->coding_type = coding_VORBIS_custom;
-        vgmstream->codec_data = init_vorbis_custom_codec_data(streamFile, 0x14, VORBIS_OGL, &cfg);
+        vgmstream->codec_data = init_vorbis_custom(streamFile, 0x14, VORBIS_OGL, &cfg);
         if (!vgmstream->codec_data) goto fail;
 
         start_offset = cfg.data_start_offset;

--- a/src/meta/p3d.c
+++ b/src/meta/p3d.c
@@ -151,7 +151,7 @@ VGMSTREAM * init_vgmstream_p3d(STREAMFILE *streamFile) {
             cfg.data_size = data_size;
             /* block_size * 3 = frame size (0x60*3=0x120 or 0x40*3=0xC0) but doesn't seem to have any significance) */
 
-            vgmstream->codec_data = init_mpeg_custom_codec_data(streamFile, start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_P3D, &cfg);
+            vgmstream->codec_data = init_mpeg_custom(streamFile, start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_P3D, &cfg);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->layout_type = layout_none;
             break;

--- a/src/meta/ps3_msf.c
+++ b/src/meta/ps3_msf.c
@@ -173,7 +173,7 @@ VGMSTREAM * init_vgmstream_ps3_msf(STREAMFILE *streamFile) {
             mpeg_codec_data *mpeg_data = NULL;
             coding_t ct;
 
-            mpeg_data = init_mpeg_codec_data(streamFile, start_offset, &ct, vgmstream->channels);
+            mpeg_data = init_mpeg(streamFile, start_offset, &ct, vgmstream->channels);
             if (!mpeg_data) goto fail;
             vgmstream->codec_data = mpeg_data;
 

--- a/src/meta/sk_aud.c
+++ b/src/meta/sk_aud.c
@@ -37,7 +37,7 @@ VGMSTREAM * init_vgmstream_sk_aud(STREAMFILE *streamFile) {
 
         vgmstream->layout_type = layout_none;
         vgmstream->coding_type = coding_VORBIS_custom;
-        vgmstream->codec_data = init_vorbis_custom_codec_data(streamFile, 0x00, VORBIS_SK, &cfg);
+        vgmstream->codec_data = init_vorbis_custom(streamFile, 0x00, VORBIS_SK, &cfg);
         if (!vgmstream->codec_data) goto fail;
 
         start_offset = cfg.data_start_offset;

--- a/src/meta/sqex_scd.c
+++ b/src/meta/sqex_scd.c
@@ -211,7 +211,7 @@ VGMSTREAM * init_vgmstream_sqex_scd(STREAMFILE *streamFile) {
             cfg.interleave = 0x800; /* for multistream [Final Fantasy XIII-2 (PS3)], otherwise ignored */
             cfg.data_size = stream_size;
 
-            mpeg_data = init_mpeg_custom_codec_data(streamFile, start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_SCD, &cfg);
+            mpeg_data = init_mpeg_custom(streamFile, start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_SCD, &cfg);
             if (!mpeg_data) goto fail;
             vgmstream->codec_data = mpeg_data;
             vgmstream->layout_type = layout_none;

--- a/src/meta/ta_aac.c
+++ b/src/meta/ta_aac.c
@@ -213,7 +213,6 @@ fail:
 VGMSTREAM * init_vgmstream_ta_aac_mobile(STREAMFILE *streamFile) {
 #ifdef VGM_USE_VORBIS
     off_t start_offset;
-    int loop_flag;
     char filename[PATH_LIMIT];
     int8_t codec_id;
 

--- a/src/meta/txth.c
+++ b/src/meta/txth.c
@@ -253,7 +253,7 @@ VGMSTREAM * init_vgmstream_txth(STREAMFILE *streamFile) {
 #ifdef VGM_USE_MPEG
         case coding_MPEG_layer3:
             vgmstream->layout_type = layout_none;
-            vgmstream->codec_data = init_mpeg_codec_data(streamFile, txth.start_offset, &coding, vgmstream->channels);
+            vgmstream->codec_data = init_mpeg(streamFile, txth.start_offset, &coding, vgmstream->channels);
             if (!vgmstream->codec_data) goto fail;
 
             break;

--- a/src/meta/ubi_raki.c
+++ b/src/meta/ubi_raki.c
@@ -132,7 +132,7 @@ VGMSTREAM * init_vgmstream_ubi_raki(STREAMFILE *streamFile) {
 #ifdef VGM_USE_MPEG
         case 0x505333206D703320: {  /* "PS3 mp3 " */
             /* chunks: "MARK" (optional seek table), "STRG" (optional description), "Msf " ("data" equivalent) */
-            vgmstream->codec_data = init_mpeg_codec_data(streamFile, start_offset, &vgmstream->coding_type, vgmstream->channels);
+            vgmstream->codec_data = init_mpeg(streamFile, start_offset, &vgmstream->coding_type, vgmstream->channels);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->layout_type = layout_none;
 

--- a/src/meta/wwise.c
+++ b/src/meta/wwise.c
@@ -285,7 +285,7 @@ VGMSTREAM * init_vgmstream_wwise(STREAMFILE *streamFile) {
                     }
                 }
 
-                vgmstream->codec_data = init_vorbis_custom_codec_data(streamFile, start_offset + setup_offset, VORBIS_WWISE, &cfg);
+                vgmstream->codec_data = init_vorbis_custom(streamFile, start_offset + setup_offset, VORBIS_WWISE, &cfg);
                 if (!vgmstream->codec_data) goto fail;
             }
             else {
@@ -330,11 +330,11 @@ VGMSTREAM * init_vgmstream_wwise(STREAMFILE *streamFile) {
                 }
 
                 /* try with the selected codebooks */
-                vgmstream->codec_data = init_vorbis_custom_codec_data(streamFile, start_offset + setup_offset, VORBIS_WWISE, &cfg);
+                vgmstream->codec_data = init_vorbis_custom(streamFile, start_offset + setup_offset, VORBIS_WWISE, &cfg);
                 if (!vgmstream->codec_data) {
                     /* codebooks failed: try again with the other type */
                     cfg.setup_type  = is_wem ? EXTERNAL_CODEBOOKS : AOTUV603_CODEBOOKS;
-                    vgmstream->codec_data = init_vorbis_custom_codec_data(streamFile, start_offset + setup_offset, VORBIS_WWISE, &cfg);
+                    vgmstream->codec_data = init_vorbis_custom(streamFile, start_offset + setup_offset, VORBIS_WWISE, &cfg);
                     if (!vgmstream->codec_data) goto fail;
                 }
             }

--- a/src/meta/xvag.c
+++ b/src/meta/xvag.c
@@ -112,7 +112,7 @@ VGMSTREAM * init_vgmstream_xvag(STREAMFILE *streamFile) {
             cfg.chunk_size = read_32bit(chunk_offset+0x1c,streamFile); /* fixed frame size */
             cfg.interleave = cfg.chunk_size * multiplier;
 
-            vgmstream->codec_data = init_mpeg_custom_codec_data(streamFile, start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_XVAG, &cfg);
+            vgmstream->codec_data = init_mpeg_custom(streamFile, start_offset, &vgmstream->coding_type, vgmstream->channels, MPEG_XVAG, &cfg);
             if (!vgmstream->codec_data) goto fail;
             vgmstream->layout_type = layout_none;
             break;

--- a/src/meta/xvag.c
+++ b/src/meta/xvag.c
@@ -10,7 +10,7 @@ VGMSTREAM * init_vgmstream_xvag(STREAMFILE *streamFile) {
     int32_t (*read_32bit)(off_t,STREAMFILE*) = NULL;
     int loop_flag = 0, channel_count, codec;
     int big_endian;
-    int sample_rate, num_samples, multiplier;
+    int sample_rate, num_samples, multiplier, multistreams = 0;
     int total_subsongs = 0, target_subsong = streamFile->stream_index;
 
     off_t start_offset, loop_start, loop_end, chunk_offset;
@@ -18,14 +18,15 @@ VGMSTREAM * init_vgmstream_xvag(STREAMFILE *streamFile) {
     size_t chunk_size;
 
     /* check extension, case insensitive */
-    if (!check_extensions(streamFile,"xvag")) goto fail;
+    if (!check_extensions(streamFile,"xvag"))
+        goto fail;
 
     /* check header */
     if (read_32bitBE(0x00,streamFile) != 0x58564147) /* "XVAG" */
         goto fail;
 
-    /* empty start_offset > little endian (also, XVAGs of the same game can use BE or LE, oddly enough) */
-    big_endian = read_8bit(0x07,streamFile) != 0;
+    /* endian flag (XVAGs of the same game can use BE or LE, usually when reusing from other platforms) */
+    big_endian = read_8bit(0x08,streamFile) & 0x01;
     if (big_endian) {
         read_32bit = read_32bitBE;
     } else {
@@ -33,32 +34,40 @@ VGMSTREAM * init_vgmstream_xvag(STREAMFILE *streamFile) {
     }
 
     start_offset = read_32bit(0x04,streamFile);
-    /* 0x08: flags? (&0x01=big endian?)  0x0a: version (chunk sizes vary) */
+    /* 0x08: flags? (&0x01=big endian, 0x02=?, 0x06=full RIFF AT9?)
+     * 0x09: flags2? (0x00/0x01/0x04, speaker mode?)
+     * 0x0a: always 0?
+     * 0x0b: version-flag? (0x5f/0x60/0x61, last has extra data) */
 
-    /* "fmat": base format */
+    /* "fmat": base format (always first) */
     if (!find_chunk(streamFile, 0x666D6174,first_offset,0, &chunk_offset,&chunk_size, big_endian, 1)) /*"fmat"*/
         goto fail;
     channel_count = read_32bit(chunk_offset+0x00,streamFile);
     codec = read_32bit(chunk_offset+0x04,streamFile);
     num_samples = read_32bit(chunk_offset+0x08,streamFile);
-    /* 0x0c: samples again? */
-    multiplier = read_32bit(chunk_offset+0x10,streamFile);
+    /* 0x0c: samples again? playable section? */
+    VGM_ASSERT(num_samples != read_32bit(chunk_offset+0x0c,streamFile), "XVAG: num_samples values don't match\n");
+
+    multiplier = read_32bit(chunk_offset+0x10,streamFile); /* 'interleave factor' */
     sample_rate = read_32bit(chunk_offset+0x14,streamFile);
     /* 0x18: datasize */
-    if (chunk_size > 0x1c) {
-        total_subsongs = read_32bit(chunk_offset+0x1c,streamFile); /* number of interleaved subsongs */
-        /* 0x20: number of multichannel substreams (for MPEG) */
 
-        if (target_subsong == 0) target_subsong = 1;
-        if (target_subsong < 0 || target_subsong > total_subsongs || total_subsongs < 1) goto fail;
+    /* extra data, seen in MPEG/ATRAC9 */
+    if (chunk_size > 0x1c) {
+        total_subsongs = read_32bit(chunk_offset+0x1c,streamFile); /* number of interleaved layers */
+        multistreams   = read_32bit(chunk_offset+0x20,streamFile); /* number of bitstreams per layer (for multistream Nch MPEG/ATRAC9) */
     }
+    if (target_subsong == 0) target_subsong = 1;
+    if (target_subsong < 0 || target_subsong > total_subsongs || total_subsongs < 1) goto fail;
 
 
     /* other chunks: */
     /* "cpan": pan/volume per channel */
+    /* "cues": cue/labels (rare) */
     /* "0000": end chunk before start_offset */
 
     /* some XVAG seem to do full loops, this should detect them as looping */
+    //todo remove, looping seems external and specified in Scream Tool's bank formats
     if (codec == 0x06) {
         loop_flag = ps_adpcm_find_loop_offsets(streamFile, channel_count, start_offset, &loop_start, &loop_end);
     }
@@ -73,10 +82,14 @@ VGMSTREAM * init_vgmstream_xvag(STREAMFILE *streamFile) {
     vgmstream->meta_type = meta_XVAG;
 
     switch (codec) {
-        case 0x06:   /* PS ADPCM: God of War III, Uncharted 1/2, Ratchet and Clank Future */
-        case 0x07: { /* Bizarro 6ch PS ADPCM: infamous 1 (todo won't play properly; algo tweak + bigger predictor table?) */
+      //case 0x??:      /* PCM? */
+        case 0x06:      /* VAG (PS ADPCM): God of War III (PS3), Uncharted 1/2 (PS3), Ratchet and Clank Future (PS3) */
+        case 0x07:      /* SVAG? (PS ADPCM with extended table): inFamous 1 (PS3) */
+            if (total_subsongs > 1 || multistreams > 1) goto fail;
+            if (multiplier > 1) goto fail;
+
             vgmstream->layout_type = layout_interleave;
-            vgmstream->interleave_block_size = 0x10;//* multiplier? (doesn't seem necessary, always 1);
+            vgmstream->interleave_block_size = 0x10;
             vgmstream->coding_type = coding_PSX;
 
             if (loop_flag) {
@@ -84,11 +97,12 @@ VGMSTREAM * init_vgmstream_xvag(STREAMFILE *streamFile) {
                 vgmstream->loop_end_sample = ps_bytes_to_samples(loop_end, vgmstream->channels);
             }
             break;
-        }
 
 #ifdef VGM_USE_MPEG
-        case 0x08: { /* MPEG: The Last of Us, Uncharted 3, Medieval Moves */
+        case 0x08: {    /* MPEG: The Last of Us (PS3), Uncharted 3 (PS3), Medieval Moves (PS3) */
             mpeg_custom_config cfg = {0};
+
+            if (total_subsongs > 1 || (multistreams > 1 && multistreams == vgmstream->channels)) goto fail;
 
             /* "mpin": mpeg info */
             /*  0x00/04: mpeg version/layer?  other: unknown or repeats of "fmat" */
@@ -106,7 +120,7 @@ VGMSTREAM * init_vgmstream_xvag(STREAMFILE *streamFile) {
 #endif
 
 #ifdef VGM_USE_ATRAC9
-        case 0x09: { /* ATRAC9: Sly Cooper and the Thievius Raccoonus, The Last of Us Remastered */
+        case 0x09: { /* ATRAC9: Sly Cooper and the Thievius Raccoonus (Vita), The Last of Us Remastered (PS4) */
             atrac9_config cfg = {0};
 
             /* "a9in": ATRAC9 info */
@@ -114,21 +128,27 @@ VGMSTREAM * init_vgmstream_xvag(STREAMFILE *streamFile) {
             if (!find_chunk(streamFile, 0x6139696E,first_offset,0, &chunk_offset,NULL, big_endian, 1)) /*"a9in"*/
                 goto fail;
 
+            cfg.type = ATRAC9_XVAG;
             cfg.channels = vgmstream->channels;
             cfg.config_data = read_32bitBE(chunk_offset+0x08,streamFile);
             cfg.encoder_delay = read_32bit(chunk_offset+0x14,streamFile);
 
-            /* Sly Cooper interleaves 'multiplier' superframes per subsong (all share config_data) */
-            cfg.interleave_skip = read_32bit(chunk_offset+0x00,streamFile) * multiplier;
-            cfg.subsong_skip = total_subsongs;
-            start_offset += (target_subsong-1) * cfg.interleave_skip * (cfg.subsong_skip-1);
-
-            /* The Last of Us Remastered has an AT9 RIFF header inside (same values, can be ignored) */
-            if (read_32bitBE(start_offset+0x00, streamFile) == 0x00000000 &&
-                read_32bitBE(start_offset+0x9c, streamFile) == 0x52494646) { /*"RIFF"*/
-                if (!find_chunk(streamFile, 0x64617461,start_offset+0x9c+0x0c,0, &start_offset,NULL, big_endian, 0)) /*"data"*/
-                    goto fail;
+            if (total_subsongs > 1 && multistreams > 1) {
+                goto fail; /* not known */
             }
+            else if (total_subsongs > 1) {
+                /* interleaves 'multiplier' superframes per subsong (all share config_data) */
+                cfg.interleave_skip = read_32bit(chunk_offset+0x00,streamFile) * multiplier;
+                cfg.subsong_skip = total_subsongs;
+                /* start in subsong's first superframe */
+                start_offset += (target_subsong-1) * cfg.interleave_skip * (cfg.subsong_skip-1);
+            }
+            else if (multistreams > 1) {
+                /* Vita multichannel (flower) interleaves streams like MPEG
+                 * PS4 (The Last of Us) uses ATRAC9's multichannel directly instead (multistreams==1) */
+                goto fail;//todo add
+            }
+            //if (multistreams == vgmstream->channels) goto fail;
 
             vgmstream->codec_data = init_atrac9(&cfg);
             if (!vgmstream->codec_data) goto fail;

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -17,10 +17,10 @@ static void try_dual_file_stereo(VGMSTREAM * opened_vgmstream, STREAMFILE *strea
 VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_adx,
     init_vgmstream_brstm,
-	init_vgmstream_bfwav,
-	init_vgmstream_bfstm,
-	init_vgmstream_mca,
-	init_vgmstream_btsnd,
+    init_vgmstream_bfwav,
+    init_vgmstream_bfstm,
+    init_vgmstream_mca,
+    init_vgmstream_btsnd,
     init_vgmstream_nds_strm,
     init_vgmstream_agsc,
     init_vgmstream_ngc_adpdtk,
@@ -31,7 +31,7 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_rs03,
     init_vgmstream_ngc_dsp_std,
     init_vgmstream_ngc_mdsp_std,
-	init_vgmstream_ngc_dsp_csmp,
+    init_vgmstream_ngc_dsp_csmp,
     init_vgmstream_cstr,
     init_vgmstream_gcsw,
     init_vgmstream_ps2_ads,
@@ -67,10 +67,10 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_sfl,
 #endif
 #if 0
-	init_vgmstream_mp4_aac,
+    init_vgmstream_mp4_aac,
 #endif
 #if defined(VGM_USE_MP4V2) && defined(VGM_USE_FDKAAC)
-	init_vgmstream_akb,
+    init_vgmstream_akb,
 #endif
     init_vgmstream_sadb,
     init_vgmstream_ps2_bmdx,
@@ -117,7 +117,7 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_ps2_dxh,
     init_vgmstream_ps2_psh,
     init_vgmstream_scd_pcm,
-	init_vgmstream_ps2_pcm,
+    init_vgmstream_ps2_pcm,
     init_vgmstream_ps2_rkv,
     init_vgmstream_ps2_psw,
     init_vgmstream_ps2_vas,
@@ -162,13 +162,13 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_rsd2vag,
     init_vgmstream_rsd2pcmb,
     init_vgmstream_rsd2xadp,
-	init_vgmstream_rsd3vag,
-	init_vgmstream_rsd3gadp,
+    init_vgmstream_rsd3vag,
+    init_vgmstream_rsd3gadp,
     init_vgmstream_rsd3pcm,
-	init_vgmstream_rsd3pcmb,
+    init_vgmstream_rsd3pcmb,
     init_vgmstream_rsd4pcmb,
     init_vgmstream_rsd4pcm,
-	init_vgmstream_rsd4radp,
+    init_vgmstream_rsd4radp,
     init_vgmstream_rsd4vag,
     init_vgmstream_rsd6vag,
     init_vgmstream_rsd6wadp,
@@ -222,19 +222,19 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_ps2_sps,
     init_vgmstream_ps2_xa2_rrp,
     init_vgmstream_nds_hwas,
-	init_vgmstream_ngc_lps,
+    init_vgmstream_ngc_lps,
     init_vgmstream_ps2_snd,
     init_vgmstream_naomi_adpcm,
-	init_vgmstream_sd9,
-	init_vgmstream_2dx9,
-	init_vgmstream_dsp_ygo,
+    init_vgmstream_sd9,
+    init_vgmstream_2dx9,
+    init_vgmstream_dsp_ygo,
     init_vgmstream_ps2_vgv,
     init_vgmstream_ngc_gcub,
     init_vgmstream_maxis_xa,
     init_vgmstream_ngc_sck_dsp,
     init_vgmstream_apple_caff,
-	init_vgmstream_pc_mxst,
-	init_vgmstream_sab,
+    init_vgmstream_pc_mxst,
+    init_vgmstream_sab,
     init_vgmstream_exakt_sc,
     init_vgmstream_wii_bns,
     init_vgmstream_wii_was,
@@ -244,8 +244,8 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_stx,
     init_vgmstream_myspd,
     init_vgmstream_his,
-	init_vgmstream_ps2_ast,
-	init_vgmstream_dmsg,
+    init_vgmstream_ps2_ast,
+    init_vgmstream_dmsg,
     init_vgmstream_ngc_dsp_aaap,
     init_vgmstream_ngc_dsp_konami,
     init_vgmstream_ps2_ster,
@@ -261,8 +261,8 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_ngc_bo2,
     init_vgmstream_dsp_ddsp,
     init_vgmstream_p3d,
-	init_vgmstream_ps2_tk1,
-	init_vgmstream_ps2_adsc,
+    init_vgmstream_ps2_tk1,
+    init_vgmstream_ps2_adsc,
     init_vgmstream_ngc_dsp_mpds,
     init_vgmstream_dsp_str_ig,
     init_vgmstream_psx_mgav,
@@ -274,55 +274,55 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_dsp_xiii,
     init_vgmstream_dsp_cabelas,
     init_vgmstream_ps2_adm,
-	init_vgmstream_ps2_lpcm,
+    init_vgmstream_ps2_lpcm,
     init_vgmstream_dsp_bdsp,
-	init_vgmstream_ps2_vms,
-	init_vgmstream_xau,
+    init_vgmstream_ps2_vms,
+    init_vgmstream_xau,
     init_vgmstream_bar,
     init_vgmstream_ffw,
     init_vgmstream_dsp_dspw,
     init_vgmstream_ps2_jstm,
     init_vgmstream_xvag,
-	init_vgmstream_ps3_cps,
+    init_vgmstream_ps3_cps,
     init_vgmstream_sqex_scd,
     init_vgmstream_ngc_nst_dsp,
     init_vgmstream_baf,
     init_vgmstream_ps3_msf,
-	init_vgmstream_nub_vag,
-	init_vgmstream_ps3_past,
+    init_vgmstream_nub_vag,
+    init_vgmstream_ps3_past,
     init_vgmstream_sgxd,
-	init_vgmstream_ngca,
-	init_vgmstream_wii_ras,
-	init_vgmstream_ps2_spm,
-	init_vgmstream_x360_tra,
-	init_vgmstream_ps2_iab,
-	init_vgmstream_ps2_strlr,
+    init_vgmstream_ngca,
+    init_vgmstream_wii_ras,
+    init_vgmstream_ps2_spm,
+    init_vgmstream_x360_tra,
+    init_vgmstream_ps2_iab,
+    init_vgmstream_ps2_strlr,
     init_vgmstream_lsf_n1nj4n,
-	init_vgmstream_vawx,
+    init_vgmstream_vawx,
     init_vgmstream_pc_snds,
-	init_vgmstream_ps2_wmus,
-	init_vgmstream_hyperscan_kvag,
-	init_vgmstream_ios_psnd,
-	init_vgmstream_pc_adp_bos,
-	init_vgmstream_pc_adp_otns,
+    init_vgmstream_ps2_wmus,
+    init_vgmstream_hyperscan_kvag,
+    init_vgmstream_ios_psnd,
+    init_vgmstream_pc_adp_bos,
+    init_vgmstream_pc_adp_otns,
     init_vgmstream_eb_sfx,
     init_vgmstream_eb_sf0,
-	init_vgmstream_ps3_klbs,
+    init_vgmstream_ps3_klbs,
     init_vgmstream_ps2_mtaf,
-	init_vgmstream_tun,
-	init_vgmstream_wpd,
-	init_vgmstream_mn_str,
-	init_vgmstream_mss,
-	init_vgmstream_ps2_hsf,
-	init_vgmstream_ps3_ivag,
-	init_vgmstream_ps2_2pfs,
+    init_vgmstream_tun,
+    init_vgmstream_wpd,
+    init_vgmstream_mn_str,
+    init_vgmstream_mss,
+    init_vgmstream_ps2_hsf,
+    init_vgmstream_ps3_ivag,
+    init_vgmstream_ps2_2pfs,
     init_vgmstream_xnb,
-	init_vgmstream_rsd6oogv,
-	init_vgmstream_ubi_ckd,
-	init_vgmstream_ps2_vbk,
-	init_vgmstream_otm,
-	init_vgmstream_bcstm,
-	init_vgmstream_3ds_idsp,
+    init_vgmstream_rsd6oogv,
+    init_vgmstream_ubi_ckd,
+    init_vgmstream_ps2_vbk,
+    init_vgmstream_otm,
+    init_vgmstream_bcstm,
+    init_vgmstream_3ds_idsp,
     init_vgmstream_kt_g1l,
     init_vgmstream_kt_wiibgm,
     init_vgmstream_ktss,
@@ -372,7 +372,7 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_ea_sps,
     init_vgmstream_ngc_vid1,
     init_vgmstream_flx,
-	init_vgmstream_mogg,
+    init_vgmstream_mogg,
 
     init_vgmstream_txth,  /* should go at the end (lower priority) */
 #ifdef VGM_USE_FFMPEG
@@ -514,9 +514,9 @@ void reset_vgmstream(VGMSTREAM * vgmstream) {
     }
 
 #if defined(VGM_USE_MP4V2) && defined(VGM_USE_FDKAAC)
-	if (vgmstream->coding_type==coding_MP4_AAC) {
-	    reset_mp4_aac(vgmstream);
-	}
+    if (vgmstream->coding_type==coding_MP4_AAC) {
+        reset_mp4_aac(vgmstream);
+    }
 #endif
 
 #ifdef VGM_USE_MPEG
@@ -543,9 +543,9 @@ void reset_vgmstream(VGMSTREAM * vgmstream) {
 #endif
 
 #ifdef VGM_USE_MAIATRAC3PLUS
-	if (vgmstream->coding_type==coding_AT3plus) {
-	    reset_at3plus(vgmstream);
-	}
+    if (vgmstream->coding_type==coding_AT3plus) {
+        reset_at3plus(vgmstream);
+    }
 #endif
 
 #ifdef VGM_USE_ATRAC9
@@ -709,10 +709,10 @@ void close_vgmstream(VGMSTREAM * vgmstream) {
 #endif
 
 #if defined(VGM_USE_MP4V2) && defined(VGM_USE_FDKAAC)
-	if (vgmstream->coding_type==coding_MP4_AAC) {
-	    free_mp4_aac(vgmstream->codec_data);
+    if (vgmstream->coding_type==coding_MP4_AAC) {
+        free_mp4_aac(vgmstream->codec_data);
         vgmstream->codec_data = NULL;
-	}
+    }
 #endif
 
 #ifdef VGM_USE_MPEG
@@ -742,10 +742,10 @@ void close_vgmstream(VGMSTREAM * vgmstream) {
 #endif
 
 #ifdef VGM_USE_MAIATRAC3PLUS
-	if (vgmstream->coding_type == coding_AT3plus) {
-	    free_at3plus(vgmstream->codec_data);
+    if (vgmstream->coding_type == coding_AT3plus) {
+        free_at3plus(vgmstream->codec_data);
         vgmstream->codec_data = NULL;
-	}
+    }
 #endif
 
 #ifdef VGM_USE_ATRAC9
@@ -941,7 +941,7 @@ void render_vgmstream(sample * buffer, int32_t sample_count, VGMSTREAM * vgmstre
         case layout_none:
             render_vgmstream_nolayout(buffer,sample_count,vgmstream);
             break;
-		case layout_mxch_blocked:
+        case layout_mxch_blocked:
         case layout_ast_blocked:
         case layout_halpst_blocked:
         case layout_xa_blocked:
@@ -964,8 +964,8 @@ void render_vgmstream(sample * buffer, int32_t sample_count, VGMSTREAM * vgmstre
         case layout_psx_mgav_blocked:
         case layout_ps2_adm_blocked:
         case layout_dsp_bdsp_blocked:
-		case layout_tra_blocked:
-		case layout_ps2_iab_blocked:
+        case layout_tra_blocked:
+        case layout_ps2_iab_blocked:
         case layout_ps2_strlr_blocked:
         case layout_rws_blocked:
         case layout_hwas_blocked:
@@ -1001,7 +1001,7 @@ int get_vgmstream_samples_per_frame(VGMSTREAM * vgmstream) {
         case coding_CRI_ADX_exp:
         case coding_CRI_ADX_enc_8:
         case coding_CRI_ADX_enc_9:
-			return (vgmstream->interleave_block_size - 2) * 2;
+            return (vgmstream->interleave_block_size - 2) * 2;
         case coding_L5_555:
             return 32;
         case coding_NGC_DSP:
@@ -1072,14 +1072,14 @@ int get_vgmstream_samples_per_frame(VGMSTREAM * vgmstream) {
         case coding_PSX_cfg:
             return (vgmstream->interleave_block_size - 1) * 2; /* decodes 1 byte into 2 bytes */
         case coding_XBOX:
-		case coding_XBOX_int:
+        case coding_XBOX_int:
         case coding_FSB_IMA:
             return 64;
         case coding_EA_XA:
         case coding_EA_XA_int:
         case coding_EA_XA_V2:
         case coding_MAXIS_XA:
-			return 28;
+            return 28;
         case coding_EA_XAS:
             return 128;
         case coding_WS:
@@ -1115,7 +1115,7 @@ int get_vgmstream_samples_per_frame(VGMSTREAM * vgmstream) {
         {
             ffmpeg_codec_data *data = (ffmpeg_codec_data *) vgmstream->codec_data;
             if (data) { 
-	            /* must know the full block size for edge loops */
+                /* must know the full block size for edge loops */
                 return data->sampleBufferBlock;
             }
             return 0;
@@ -1135,12 +1135,12 @@ int get_vgmstream_samples_per_frame(VGMSTREAM * vgmstream) {
         case coding_CRI_HCA:
             return clHCA_samplesPerBlock;
 #if defined(VGM_USE_MP4V2) && defined(VGM_USE_FDKAAC)
-		case coding_MP4_AAC:
-			return ((mp4_aac_codec_data*)vgmstream->codec_data)->samples_per_frame;
+        case coding_MP4_AAC:
+            return ((mp4_aac_codec_data*)vgmstream->codec_data)->samples_per_frame;
 #endif
 #ifdef VGM_USE_MAIATRAC3PLUS
-		case coding_AT3plus:
-			return 2048 - ((maiatrac3plus_codec_data*)vgmstream->codec_data)->samples_discard;
+        case coding_AT3plus:
+            return 2048 - ((maiatrac3plus_codec_data*)vgmstream->codec_data)->samples_discard;
 #endif
 #ifdef VGM_USE_ATRAC9
         case coding_ATRAC9:
@@ -1225,7 +1225,7 @@ int get_vgmstream_frame_size(VGMSTREAM * vgmstream) {
         case coding_XA:
             return 14*vgmstream->channels;
         case coding_XBOX:
-		case coding_XBOX_int:
+        case coding_XBOX_int:
         case coding_FSB_IMA:
             return 36;
         case coding_EA_XA:
@@ -1260,7 +1260,7 @@ int get_vgmstream_frame_size(VGMSTREAM * vgmstream) {
         case coding_G719:
 #endif
 #ifdef VGM_USE_MAIATRAC3PLUS
-		case coding_AT3plus:
+        case coding_AT3plus:
 #endif
 #ifdef VGM_USE_FFMPEG
         case coding_FFmpeg:
@@ -1627,11 +1627,11 @@ void decode_vgmstream(VGMSTREAM * vgmstream, int samples_written, int samples_to
             break;
 #endif
 #if defined(VGM_USE_MP4V2) && defined(VGM_USE_FDKAAC)
-		case coding_MP4_AAC:
-			decode_mp4_aac(vgmstream->codec_data,
-				buffer+samples_written*vgmstream->channels,samples_to_do,
-				vgmstream->channels);
-			break;
+        case coding_MP4_AAC:
+            decode_mp4_aac(vgmstream->codec_data,
+                buffer+samples_written*vgmstream->channels,samples_to_do,
+                vgmstream->channels);
+            break;
 #endif
         case coding_SDX2:
             for (chan=0;chan<vgmstream->channels;chan++) {
@@ -1784,15 +1784,15 @@ void decode_vgmstream(VGMSTREAM * vgmstream, int samples_written, int samples_to
             break;
 #endif
 #ifdef VGM_USE_MAIATRAC3PLUS
-		case coding_AT3plus:
-			for (chan=0;chan<vgmstream->channels;chan++) {
-				decode_at3plus(vgmstream,
-					buffer+samples_written*vgmstream->channels+chan,
-					vgmstream->channels,
-					samples_to_do,
-					chan);
-			}
-			break;
+        case coding_AT3plus:
+            for (chan=0;chan<vgmstream->channels;chan++) {
+                decode_at3plus(vgmstream,
+                    buffer+samples_written*vgmstream->channels+chan,
+                    vgmstream->channels,
+                    samples_to_do,
+                    chan);
+            }
+            break;
 #endif
 #ifdef VGM_USE_ATRAC9
         case coding_ATRAC9:

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -111,7 +111,7 @@ typedef enum {
     coding_G721,            /* CCITT G.721 */
 
     coding_XA,              /* CD-ROM XA */
-    coding_PSX,				/* Sony PS ADPCM (VAG) */
+    coding_PSX,             /* Sony PS ADPCM (VAG) */
     coding_PSX_badflags,    /* Sony PS ADPCM with custom flag byte */
     coding_PSX_bmdx,        /* Sony PS ADPCM with BMDX encryption */
     coding_PSX_cfg,         /* Sony PS ADPCM with configurable frame size (FF XI, SGXD type 5, Bizarre Creations) */
@@ -126,7 +126,7 @@ typedef enum {
     coding_IMA,             /* IMA ADPCM (stereo or mono, low nibble first) */
     coding_IMA_int,         /* IMA ADPCM (mono/interleave, low nibble first) */
     coding_DVI_IMA,         /* DVI IMA ADPCM (stereo or mono, high nibble first) */
-    coding_DVI_IMA_int,		/* DVI IMA ADPCM (mono/interleave, high nibble first) */
+    coding_DVI_IMA_int,     /* DVI IMA ADPCM (mono/interleave, high nibble first) */
     coding_3DS_IMA,         /* 3DS IMA ADPCM */
     coding_MS_IMA,          /* Microsoft IMA ADPCM */
     coding_XBOX,            /* XBOX IMA ADPCM */
@@ -195,11 +195,11 @@ typedef enum {
 #endif
 
 #if defined(VGM_USE_MP4V2) && defined(VGM_USE_FDKAAC)
-	coding_MP4_AAC,         /* AAC (MDCT-based) */
+    coding_MP4_AAC,         /* AAC (MDCT-based) */
 #endif
 
 #ifdef VGM_USE_MAIATRAC3PLUS
-	coding_AT3plus,         /* Sony ATRAC3plus (MDCT-based) */
+    coding_AT3plus,         /* Sony ATRAC3plus (MDCT-based) */
 #endif
 
 #ifdef VGM_USE_ATRAC9
@@ -259,7 +259,7 @@ typedef enum {
     layout_mus_acm,         /* mus has multi-files to deal with */
     layout_aix,             /* CRI AIX's wheels within wheels */
     layout_aax,             /* CRI AAX's wheels within databases */
-	layout_scd_int,         /* deinterleave done by the SCDINTSTREAMFILE */
+    layout_scd_int,         /* deinterleave done by the SCDINTSTREAMFILE */
 
 #ifdef VGM_USE_VORBIS
     layout_ogg_vorbis,      /* ogg vorbis file */
@@ -280,14 +280,14 @@ typedef enum {
     meta_DSP_JETTERS,       /* Bomberman Jetters .dsp */
     meta_DSP_MSS,           /* ? */
     meta_DSP_GCM,           /* ? */
-    meta_DSP_STR,			/* Conan .str files */
+    meta_DSP_STR,           /* Conan .str files */
     meta_DSP_SADB,          /* .sad */
     meta_DSP_WSI,           /* .wsi */
-    meta_DSP_WII_IDSP,		/* .gcm with IDSP header */
+    meta_DSP_WII_IDSP,      /* .gcm with IDSP header */
     meta_DSP_WII_MUS,       /* .mus */
-    meta_DSP_WII_WSD,		/* Phantom Brave (WII) */
-    meta_WII_NDP,		    /* Vertigo (Wii) */
-	meta_DSP_YGO,           /* Konami: Yu-Gi-Oh! The Falsebound Kingdom (NGC), Hikaru no Go 3 (NGC) */
+    meta_DSP_WII_WSD,       /* Phantom Brave (WII) */
+    meta_WII_NDP,           /* Vertigo (Wii) */
+    meta_DSP_YGO,           /* Konami: Yu-Gi-Oh! The Falsebound Kingdom (NGC), Hikaru no Go 3 (NGC) */
 
     /* Nintendo */
     meta_STRM,              /* Nintendo STRM */
@@ -298,15 +298,15 @@ typedef enum {
     meta_RWAR,              /* single-stream RWAR */
     meta_RWAV,              /* contents of RWAR */
     meta_CWAV,              /* contents of CWAR */
-	meta_FWAV,				/* contents of FWAR */
+    meta_FWAV,              /* contents of FWAR */
     meta_RSTM_SPM,          /* RSTM with 44->22khz hack */
     meta_THP,               /* THP movie files */
     meta_RSTM_shrunken,     /* Atlus' mutant shortened RSTM */
-	meta_NDS_SWAV,		    /* Asphalt Urban GT 1 & 2 */
-	meta_NDS_RRDS,		    /* Ridge Racer DS */
+    meta_NDS_SWAV,          /* Asphalt Urban GT 1 & 2 */
+    meta_NDS_RRDS,          /* Ridge Racer DS */
     meta_WII_BNS,           /* Wii BNS Banner Sound (similar to RSTM) */
     meta_STX,               /* Pikmin .stx */
-	meta_WIIU_BTSND,		/* Wii U Boot Sound */
+    meta_WIIU_BTSND,        /* Wii U Boot Sound */
 
     meta_ADX_03,            /* CRI ADX "type 03" */
     meta_ADX_04,            /* CRI ADX "type 04" */
@@ -319,157 +319,157 @@ typedef enum {
     meta_RSF,               /* Retro Studios RSF (Metroid Prime .rsf) [no header_id] */
     meta_HALPST,            /* HAL Labs HALPST */
     meta_GCSW,              /* GCSW (PCM) */
-    meta_CFN,				/* Namco CAF Audio File */
+    meta_CFN,               /* Namco CAF Audio File */
     meta_MYSPD,             /* U-Sing .myspd */
     meta_HIS,               /* Her Ineractive .his */
     meta_BNSF,              /* Bandai Namco Sound Format */
 
     meta_PSX_XA,            /* CD-ROM XA */
-    meta_PS2_SShd,			/* .ADS with SShd header */
-    meta_PS2_NPSF,			/* Namco Production Sound File */
+    meta_PS2_SShd,          /* .ADS with SShd header */
+    meta_PS2_NPSF,          /* Namco Production Sound File */
     meta_PS2_RXWS,          /* Sony games (Genji, Okage Shadow King, Arc The Lad Twilight of Spirits) */
-    meta_PS2_RAW,			/* RAW Interleaved Format */
-    meta_PS2_EXST,			/* Shadow of Colossus EXST */
-    meta_PS2_SVAG,			/* Konami SVAG */
-    meta_PS2_MIB,			/* MIB File */
-    meta_PS2_MIB_MIH,		/* MIB File + MIH Header*/
-    meta_PS2_MIC,			/* KOEI MIC File */
-    meta_PS2_VAGi,			/* VAGi Interleaved File */
-    meta_PS2_VAGp,			/* VAGp Mono File */
-    meta_PS2_VAGm,			/* VAGp Mono File */
-    meta_PS2_pGAV,			/* VAGp with Little Endian Header */
+    meta_PS2_RAW,           /* RAW Interleaved Format */
+    meta_PS2_EXST,          /* Shadow of Colossus EXST */
+    meta_PS2_SVAG,          /* Konami SVAG */
+    meta_PS2_MIB,           /* MIB File */
+    meta_PS2_MIB_MIH,       /* MIB File + MIH Header*/
+    meta_PS2_MIC,           /* KOEI MIC File */
+    meta_PS2_VAGi,          /* VAGi Interleaved File */
+    meta_PS2_VAGp,          /* VAGp Mono File */
+    meta_PS2_VAGm,          /* VAGp Mono File */
+    meta_PS2_pGAV,          /* VAGp with Little Endian Header */
     meta_PSX_GMS,           /* GMS File (used in PS1 & PS2) [no header_id] */
-    meta_PS2_STR,			/* Pacman STR+STH files */
-    meta_PS2_ILD,			/* ILD File */
-    meta_PS2_PNB,			/* PsychoNauts Bgm File */
-    meta_PS2_VAGs,			/* VAG Stereo from Kingdom Hearts */
-    meta_PS2_VPK,			/* VPK Audio File */
+    meta_PS2_STR,           /* Pacman STR+STH files */
+    meta_PS2_ILD,           /* ILD File */
+    meta_PS2_PNB,           /* PsychoNauts Bgm File */
+    meta_PS2_VAGs,          /* VAG Stereo from Kingdom Hearts */
+    meta_PS2_VPK,           /* VPK Audio File */
     meta_PS2_BMDX,          /* Beatmania thing */
     meta_PS2_IVB,           /* Langrisser 3 IVB */
     meta_PS2_SND,           /* some Might & Magics SSND header */
     meta_PS2_SVS,           /* Square SVS */
-    meta_XSS,				/* Dino Crisis 3 */
-    meta_SL3,				/* Test Drive Unlimited */
-    meta_HGC1,				/* Knights of the Temple 2 */
-    meta_AUS,				/* Various Capcom games */
-    meta_RWS,				/* RenderWare games (only when using RW Audio middleware) */
+    meta_XSS,               /* Dino Crisis 3 */
+    meta_SL3,               /* Test Drive Unlimited */
+    meta_HGC1,              /* Knights of the Temple 2 */
+    meta_AUS,               /* Various Capcom games */
+    meta_RWS,               /* RenderWare games (only when using RW Audio middleware) */
     meta_FSB1,              /* FMOD Sample Bank, version 1 */
     meta_FSB2,              /* FMOD Sample Bank, version 2 */
     meta_FSB3,              /* FMOD Sample Bank, version 3.0/3.1 */
     meta_FSB4,              /* FMOD Sample Bank, version 4 */
     meta_FSB5,              /* FMOD Sample Bank, version 5 */
-    meta_RWX,				/* Air Force Delta Storm (XBOX) */
-    meta_XWB,				/* Microsoft XACT framework (Xbox, X360, Windows) */
+    meta_RWX,               /* Air Force Delta Storm (XBOX) */
+    meta_XWB,               /* Microsoft XACT framework (Xbox, X360, Windows) */
     meta_PS2_XA30,          /* Driver - Parallel Lines (PS2) */
-    meta_MUSC,				/* Krome PS2 games */
-    meta_MUSX_V004,			/* Spyro Games, possibly more */
-    meta_MUSX_V005,			/* Spyro Games, possibly more */
-    meta_MUSX_V006,			/* Spyro Games, possibly more */
-    meta_MUSX_V010,			/* Spyro Games, possibly more */
-    meta_MUSX_V201,			/* Sphinx and the cursed Mummy */
-    meta_LEG,				/* Legaia 2 [no header_id] */
-    meta_FILP,				/* Resident Evil - Dead Aim */
-    meta_IKM,				/* Zwei! */
-    meta_SFS,				/* Baroque */
-    meta_BG00,				/* Ibara, Mushihimesama */
-    meta_PS2_RSTM,			/* Midnight Club 3 */
-    meta_PS2_KCES,			/* Dance Dance Revolution */
-    meta_PS2_DXH,			/* Tokobot Plus - Myteries of the Karakuri */
-    meta_PS2_PSH,			/* Dawn of Mana - Seiken Densetsu 4 */
-    meta_SCD_PCM,			/* Lunar - Eternal Blue */
-    meta_PS2_PCM,			/* Konami KCEJ East: Ephemeral Fantasia, Yu-Gi-Oh! The Duelists of the Roses, 7 Blades */
-    meta_PS2_RKV,			/* Legacy of Kain - Blood Omen 2 */
-    meta_PS2_PSW,			/* Rayman Raving Rabbids */
-    meta_PS2_VAS,			/* Pro Baseball Spirits 5 */
-    meta_PS2_TEC,			/* TECMO badflagged stream */
-    meta_PS2_ENTH,			/* Enthusia */
-    meta_SDT,				/* Baldur's Gate - Dark Alliance */
-    meta_NGC_TYDSP,			/* Ty - The Tasmanian Tiger */
-    meta_NGC_SWD,			/* Conflict - Desert Storm 1 & 2 */
+    meta_MUSC,              /* Krome PS2 games */
+    meta_MUSX_V004,         /* Spyro Games, possibly more */
+    meta_MUSX_V005,         /* Spyro Games, possibly more */
+    meta_MUSX_V006,         /* Spyro Games, possibly more */
+    meta_MUSX_V010,         /* Spyro Games, possibly more */
+    meta_MUSX_V201,         /* Sphinx and the cursed Mummy */
+    meta_LEG,               /* Legaia 2 [no header_id] */
+    meta_FILP,              /* Resident Evil - Dead Aim */
+    meta_IKM,               /* Zwei! */
+    meta_SFS,               /* Baroque */
+    meta_BG00,              /* Ibara, Mushihimesama */
+    meta_PS2_RSTM,          /* Midnight Club 3 */
+    meta_PS2_KCES,          /* Dance Dance Revolution */
+    meta_PS2_DXH,           /* Tokobot Plus - Myteries of the Karakuri */
+    meta_PS2_PSH,           /* Dawn of Mana - Seiken Densetsu 4 */
+    meta_SCD_PCM,           /* Lunar - Eternal Blue */
+    meta_PS2_PCM,           /* Konami KCEJ East: Ephemeral Fantasia, Yu-Gi-Oh! The Duelists of the Roses, 7 Blades */
+    meta_PS2_RKV,           /* Legacy of Kain - Blood Omen 2 */
+    meta_PS2_PSW,           /* Rayman Raving Rabbids */
+    meta_PS2_VAS,           /* Pro Baseball Spirits 5 */
+    meta_PS2_TEC,           /* TECMO badflagged stream */
+    meta_PS2_ENTH,          /* Enthusia */
+    meta_SDT,               /* Baldur's Gate - Dark Alliance */
+    meta_NGC_TYDSP,         /* Ty - The Tasmanian Tiger */
+    meta_NGC_SWD,           /* Conflict - Desert Storm 1 & 2 */
     meta_CAPDSP,            /* Capcom DSP Header [no header_id] */
-    meta_DC_STR,			/* SEGA Stream Asset Builder */
-    meta_DC_STR_V2,			/* variant of SEGA Stream Asset Builder */
-    meta_NGC_BH2PCM,		/* Bio Hazard 2 */
-    meta_SAT_SAP,			/* Bubble Symphony */
-    meta_DC_IDVI,			/* Eldorado Gate */
-    meta_KRAW,				/* Geometry Wars - Galaxies */
-    meta_PS2_OMU,			/* PS2 Int file with Header */
-    meta_PS2_XA2,			/* XG3 Extreme-G Racing */
-    meta_IDSP,				/* Chronicles of Narnia, Soul Calibur Legends, Mario Strikers Charged */
-	meta_SPT_SPD,			/* Various (SPT+SPT DSP) */
-    meta_ISH_ISD,			/* Various (ISH+ISD DSP) */
-    meta_GSP_GSB,			/* Tecmo games (Super Swing Golf 1 & 2, Quamtum Theory) */
-    meta_YDSP,				/* WWE Day of Reckoning */
+    meta_DC_STR,            /* SEGA Stream Asset Builder */
+    meta_DC_STR_V2,         /* variant of SEGA Stream Asset Builder */
+    meta_NGC_BH2PCM,        /* Bio Hazard 2 */
+    meta_SAT_SAP,           /* Bubble Symphony */
+    meta_DC_IDVI,           /* Eldorado Gate */
+    meta_KRAW,              /* Geometry Wars - Galaxies */
+    meta_PS2_OMU,           /* PS2 Int file with Header */
+    meta_PS2_XA2,           /* XG3 Extreme-G Racing */
+    meta_IDSP,              /* Chronicles of Narnia, Soul Calibur Legends, Mario Strikers Charged */
+    meta_SPT_SPD,           /* Various (SPT+SPT DSP) */
+    meta_ISH_ISD,           /* Various (ISH+ISD DSP) */
+    meta_GSP_GSB,           /* Tecmo games (Super Swing Golf 1 & 2, Quamtum Theory) */
+    meta_YDSP,              /* WWE Day of Reckoning */
     meta_FFCC_STR,          /* Final Fantasy: Crystal Chronicles */
     
-    meta_WAA_WAC_WAD_WAM,	/* Beyond Good & Evil */
-    meta_GCA,				/* Metal Slug Anthology */
-    meta_MSVP,				/* Popcap Hits */
-    meta_NGC_SSM,			/* Golden Gashbell Full Power */
-    meta_PS2_JOE,			/* Wall-E / Pixar games */
+    meta_WAA_WAC_WAD_WAM,   /* Beyond Good & Evil */
+    meta_GCA,               /* Metal Slug Anthology */
+    meta_MSVP,              /* Popcap Hits */
+    meta_NGC_SSM,           /* Golden Gashbell Full Power */
+    meta_PS2_JOE,           /* Wall-E / Pixar games */
 
-    meta_NGC_YMF,			/* WWE WrestleMania X8 */
+    meta_NGC_YMF,           /* WWE WrestleMania X8 */
     meta_SADL,              /* .sad */
     meta_PS2_CCC,           /* Tokyo Xtreme Racer DRIFT 2 */
     meta_PSX_FAG,           /* Jackie Chan - Stuntmaster */
     meta_PS2_MIHB,          /* Merged MIH+MIB */
     meta_NGC_PDT,           /* Mario Party 6 */
-    meta_DC_ASD,    		/* Miss Moonligh */
-    meta_NAOMI_SPSD,		/* Guilty Gear X */
+    meta_DC_ASD,            /* Miss Moonligh */
+    meta_NAOMI_SPSD,        /* Guilty Gear X */
     
-    meta_RSD2VAG,			/* RSD2VAG */
-    meta_RSD2PCMB,			/* RSD2PCMB */
-    meta_RSD2XADP,			/* RSD2XADP */
-	meta_RSD3VAG,			/* RSD3VAG */
-	meta_RSD3GADP,			/* RSD3GADP */
-    meta_RSD3PCM,		  	/* RSD3PCM */
-    meta_RSD3PCMB,			/* RSD3PCMB */
-    meta_RSD4PCMB,			/* RSD4PCMB */
-    meta_RSD4PCM,			/* RSD4PCM */
-	meta_RSD4RADP,			/* RSD4RADP */
-    meta_RSD4VAG,			/* RSD4VAG */
-    meta_RSD6VAG,			/* RSD6VAG */
-    meta_RSD6WADP,			/* RSD6WADP */
-    meta_RSD6XADP,			/* RSD6XADP */
-    meta_RSD6RADP,			/* RSD6RADP */
-	meta_RSD6OOGV,          /* RSD6OOGV */
+    meta_RSD2VAG,           /* RSD2VAG */
+    meta_RSD2PCMB,          /* RSD2PCMB */
+    meta_RSD2XADP,          /* RSD2XADP */
+    meta_RSD3VAG,           /* RSD3VAG */
+    meta_RSD3GADP,          /* RSD3GADP */
+    meta_RSD3PCM,           /* RSD3PCM */
+    meta_RSD3PCMB,          /* RSD3PCMB */
+    meta_RSD4PCMB,          /* RSD4PCMB */
+    meta_RSD4PCM,           /* RSD4PCM */
+    meta_RSD4RADP,          /* RSD4RADP */
+    meta_RSD4VAG,           /* RSD4VAG */
+    meta_RSD6VAG,           /* RSD6VAG */
+    meta_RSD6WADP,          /* RSD6WADP */
+    meta_RSD6XADP,          /* RSD6XADP */
+    meta_RSD6RADP,          /* RSD6RADP */
+    meta_RSD6OOGV,          /* RSD6OOGV */
     meta_RSD6XMA,           /* RSD6XMA */
 
-    meta_PS2_ASS,			/* ASS */
-    meta_PS2_SEG,			/* Eragon */
+    meta_PS2_ASS,           /* ASS */
+    meta_PS2_SEG,           /* Eragon */
     meta_XBOX_SEG,          /* Eragon */
-    meta_NDS_STRM_FFTA2,	/* Final Fantasy Tactics A2 */
-    meta_STR_ASR,			/* Donkey Kong Jet Race */
-    meta_ZWDSP,				/* Zack and Wiki */
-    meta_VGS,				/* Guitar Hero Encore - Rocks the 80s */
-    meta_DC_DCSW_DCS,		/* Evil Twin - Cypriens Chronicles (DC) */
-    meta_WII_SMP,			/* Mushroom Men - The Spore Wars */
+    meta_NDS_STRM_FFTA2,    /* Final Fantasy Tactics A2 */
+    meta_STR_ASR,           /* Donkey Kong Jet Race */
+    meta_ZWDSP,             /* Zack and Wiki */
+    meta_VGS,               /* Guitar Hero Encore - Rocks the 80s */
+    meta_DC_DCSW_DCS,       /* Evil Twin - Cypriens Chronicles (DC) */
+    meta_WII_SMP,           /* Mushroom Men - The Spore Wars */
     meta_WII_SNG,           /* Excite Trucks */
-    meta_EMFF_PS2,			/* Eidos Music File Format for PS2*/
-    meta_EMFF_NGC,			/* Eidos Music File Format for NGC/WII */
-    meta_SAT_BAKA,			/* Crypt Killer */
+    meta_EMFF_PS2,          /* Eidos Music File Format for PS2*/
+    meta_EMFF_NGC,          /* Eidos Music File Format for NGC/WII */
+    meta_SAT_BAKA,          /* Crypt Killer */
     meta_PS2_VSF,           /* Musashi: Samurai Legend */
-	meta_PS2_VSF_TTA,       /* Tiny Toon Adventures: Defenders of the Universe */
-	meta_ADS,               /* Gauntlet Dark Legends (GC) */
-	meta_PS2_SPS,           /* Ape Escape 2 */
+    meta_PS2_VSF_TTA,       /* Tiny Toon Adventures: Defenders of the Universe */
+    meta_ADS,               /* Gauntlet Dark Legends (GC) */
+    meta_PS2_SPS,           /* Ape Escape 2 */
     meta_PS2_XA2_RRP,       /* RC Revenge Pro */
     meta_NGC_DSP_KONAMI,    /* Konami DSP header, found in various games */
-	meta_UBI_CKD,           /* Ubisoft CKD RIFF header (Rayman Origins Wii) */
+    meta_UBI_CKD,           /* Ubisoft CKD RIFF header (Rayman Origins Wii) */
 
-    meta_XBOX_WAVM,			/* XBOX WAVM File */
-    meta_XBOX_RIFF,			/* XBOX RIFF/WAVE File */
-    meta_XBOX_WVS,			/* XBOX WVS */
-    meta_NGC_WVS,			/* Metal Arms - Glitch in the System */
-    meta_XBOX_MATX,			/* XBOX MATX */
-    meta_XBOX_XMU,			/* XBOX XMU */
-    meta_XBOX_XVAS,			/* XBOX VAS */
+    meta_XBOX_WAVM,         /* XBOX WAVM File */
+    meta_XBOX_RIFF,         /* XBOX RIFF/WAVE File */
+    meta_XBOX_WVS,          /* XBOX WVS */
+    meta_NGC_WVS,           /* Metal Arms - Glitch in the System */
+    meta_XBOX_MATX,         /* XBOX MATX */
+    meta_XBOX_XMU,          /* XBOX XMU */
+    meta_XBOX_XVAS,         /* XBOX VAS */
     
     meta_EA_SCHL,           /* Electronic Arts SCHl with variable header */
     meta_EA_SCHL_fixed,     /* Electronic Arts SCHl with fixed header */
     meta_EA_BNK,            /* Electronic Arts BNK */
     meta_EA_1SNH,           /* Electronic Arts 1SNh/EACS */
 
-    meta_RAW,				/* RAW PCM file */
+    meta_RAW,               /* RAW PCM file */
 
     meta_GENH,              /* generic header */
 
@@ -488,7 +488,7 @@ typedef enum {
     meta_RIFX_WAVE_smpl,    /* RIFX w/ loop data in smpl chunk */
     meta_XNB,               /* XNA Game Studio 4.0 */
     meta_PC_MXST,           /* Lego Island MxSt */
-	meta_SAB,		        /* Worms 4 Mayhem SAB+SOB file */
+    meta_SAB,               /* Worms 4 Mayhem SAB+SOB file */
     meta_NWA,               /* Visual Art's NWA */
     meta_NWA_NWAINFOINI,    /* Visual Art's NWA w/ NWAINFO.INI for looping */
     meta_NWA_GAMEEXEINI,    /* Visual Art's NWA w/ Gameexe.ini for looping */
@@ -497,24 +497,24 @@ typedef enum {
     meta_ACM,               /* InterPlay ACM header */
     meta_MUS_ACM,           /* MUS playlist of InterPlay ACM files */
     meta_DEC,               /* Falcom PC games (Xanadu Next, Gurumin) */
-    meta_VS,				/* Men in Black .vs */
+    meta_VS,                /* Men in Black .vs */
     meta_FFXI_BGW,          /* FFXI (PC) BGW */
     meta_FFXI_SPW,          /* FFXI (PC) SPW */
-    meta_STS_WII,			/* Shikigami No Shiro 3 STS Audio File */
-    meta_PS2_P2BT,			/* Pop'n'Music 7 Audio File */
-    meta_PS2_GBTS,			/* Pop'n'Music 9 Audio File */
+    meta_STS_WII,           /* Shikigami No Shiro 3 STS Audio File */
+    meta_PS2_P2BT,          /* Pop'n'Music 7 Audio File */
+    meta_PS2_GBTS,          /* Pop'n'Music 9 Audio File */
     meta_NGC_DSP_IADP,      /* Gamecube Interleave DSP */
-	meta_PS2_TK5,			/* Tekken 5 Stream Files */
-	meta_WII_STR,			/* House of The Dead Overkill STR+STH */
-	meta_PS2_MCG,			/* Gunvari MCG Files (was name .GCM on disk) */
+    meta_PS2_TK5,           /* Tekken 5 Stream Files */
+    meta_WII_STR,           /* House of The Dead Overkill STR+STH */
+    meta_PS2_MCG,           /* Gunvari MCG Files (was name .GCM on disk) */
     meta_ZSD,               /* Dragon Booster ZSD */
     meta_RedSpark,          /* "RedSpark" RSD (MadWorld) */
-	meta_PC_IVAUD,			/* .ivaud GTA IV */
-    meta_NDS_HWAS,			/* Spider-Man 3, Tony Hawk's Downhill Jam, possibly more... */
-	meta_NGC_LPS,			/* Rave Master (Groove Adventure Rave)(GC) */
-    meta_NAOMI_ADPCM,		/* NAOMI/NAOMI2 ARcade games */
-	meta_SD9,               /* beatmaniaIIDX16 - EMPRESS (Arcade) */
-	meta_2DX9,              /* beatmaniaIIDX16 - EMPRESS (Arcade) */
+    meta_PC_IVAUD,          /* .ivaud GTA IV */
+    meta_NDS_HWAS,          /* Spider-Man 3, Tony Hawk's Downhill Jam, possibly more... */
+    meta_NGC_LPS,           /* Rave Master (Groove Adventure Rave)(GC) */
+    meta_NAOMI_ADPCM,       /* NAOMI/NAOMI2 ARcade games */
+    meta_SD9,               /* beatmaniaIIDX16 - EMPRESS (Arcade) */
+    meta_2DX9,              /* beatmaniaIIDX16 - EMPRESS (Arcade) */
     meta_PS2_VGV,           /* Rune: Viking Warlord */
     meta_NGC_GCUB,          /* Sega Soccer Slam */
     meta_MAXIS_XA,          /* Sim City 3000 (PC) */
@@ -525,9 +525,9 @@ typedef enum {
     meta_PONA_3DO,          /* Policenauts (3DO) */
     meta_PONA_PSX,          /* Policenauts (PSX) */
     meta_XBOX_HLWAV,        /* Half Life 2 (XBOX) */
-	meta_PS2_AST,			/* Some KOEI game (PS2) */
-	meta_DMSG,				/* Nightcaster II - Equinox (XBOX) */
-    meta_NGC_DSP_AAAP,  	/* Turok: Evolution (NGC), Vexx (NGC) */
+    meta_PS2_AST,           /* Some KOEI game (PS2) */
+    meta_DMSG,              /* Nightcaster II - Equinox (XBOX) */
+    meta_NGC_DSP_AAAP,      /* Turok: Evolution (NGC), Vexx (NGC) */
     meta_PS2_STER,          /* Juuni Kokuki: Kakukaku Taru Ou Michi Beni Midori no Uka */
     meta_PS2_WB,            /* Shooting Love. ~TRIZEAL~ */
     meta_S14,               /* raw Siren 14, 24kbit mono */
@@ -539,7 +539,7 @@ typedef enum {
     meta_PS2_KHV,           /* Kingdom Hearts 2 VAG streams */
     meta_PC_SMP,            /* Ghostbusters PC .smp */
     meta_P3D,               /* Prototype P3D */
-	meta_PS2_TK1,           /* Tekken (NamCollection) */
+    meta_PS2_TK1,           /* Tekken (NamCollection) */
     meta_PS2_ADSC,          /* Kenka Bancho 2: Full Throttle */
     meta_NGC_BO2,           /* Blood Omen 2 (NGC) */
     meta_DSP_DDSP,          /* Various (2 dsp files stuck together */
@@ -552,10 +552,10 @@ typedef enum {
     meta_DSP_XIII,          /* XIII, possibly more (Ubisoft header???) */
     meta_DSP_CABELAS,       /* Cabelas games */
     meta_PS2_ADM,           /* Dragon Quest 5 */
-	meta_PS2_LPCM,          /* Ah! My Goddess */
+    meta_PS2_LPCM,          /* Ah! My Goddess */
     meta_DSP_BDSP,          /* Ah! My Goddess */
-	meta_PS2_VMS,           /* Autobahn Raser - Police Madness */
-	meta_XAU,			    /* XPEC Entertainment (Beat Down (PS2 Xbox), Spectral Force Chronicle (PS2)) */
+    meta_PS2_VMS,           /* Autobahn Raser - Police Madness */
+    meta_XAU,               /* XPEC Entertainment (Beat Down (PS2 Xbox), Spectral Force Chronicle (PS2)) */
     meta_GH3_BAR,           /* Guitar Hero III Mobile .bar */
     meta_FFW,               /* Freedom Fighters [NGC] */
     meta_DSP_DSPW,          /* Sengoku Basara 3 [WII] */
@@ -563,47 +563,47 @@ typedef enum {
     meta_SQEX_SCD,          /* Square-Enix SCD */
     meta_NGC_NST_DSP,       /* Animaniacs [NGC] */
     meta_BAF,               /* Bizarre Creations (Blur, James Bond) */
-	meta_XVAG,              /* Ratchet & Clank Future: Quest for Booty (PS3) */
-	meta_PS3_CPS,           /* Eternal Sonata (PS3) */
+    meta_XVAG,              /* Ratchet & Clank Future: Quest for Booty (PS3) */
+    meta_PS3_CPS,           /* Eternal Sonata (PS3) */
     meta_PS3_MSF,           /* MSF header */
-	meta_NUB_VAG,           /* Namco VAG from NUB archives */
-	meta_PS3_PAST,          /* Bakugan Battle Brawlers (PS3) */
+    meta_NUB_VAG,           /* Namco VAG from NUB archives */
+    meta_PS3_PAST,          /* Bakugan Battle Brawlers (PS3) */
     meta_SGXD,              /* Sony: Folklore, Genji, Tokyo Jungle (PS3), Brave Story, Kurohyo (PSP) */
-	meta_NGCA,              /* GoldenEye 007 (Wii) */
-	meta_WII_RAS,           /* Donkey Kong Country Returns (Wii) */
-	meta_PS2_SPM,           /* Lethal Skies Elite Pilot: Team SW */
-	meta_X360_TRA,			/* Def Jam Rapstar */
-	meta_PS2_VGS,			/* Princess Soft PS2 games */
-	meta_PS2_IAB,			/* Ueki no Housoku - Taosu ze Robert Juudan!! (PS2) */
-	meta_PS2_STRLR,         /* The Bouncer */
+    meta_NGCA,              /* GoldenEye 007 (Wii) */
+    meta_WII_RAS,           /* Donkey Kong Country Returns (Wii) */
+    meta_PS2_SPM,           /* Lethal Skies Elite Pilot: Team SW */
+    meta_X360_TRA,          /* Def Jam Rapstar */
+    meta_PS2_VGS,           /* Princess Soft PS2 games */
+    meta_PS2_IAB,           /* Ueki no Housoku - Taosu ze Robert Juudan!! (PS2) */
+    meta_PS2_STRLR,         /* The Bouncer */
     meta_LSF_N1NJ4N,        /* .lsf n1nj4n Fastlane Street Racing (iPhone) */
     meta_VAWX,              /* feelplus: No More Heroes Heroes Paradise, Moon Diver */
-    meta_PC_SNDS,           // Incredibles PC .snds
-    meta_PS2_WMUS,          // The Warriors (PS2)
-    meta_HYPERSCAN_KVAG,	// Hyperscan KVAG/BVG 
-    meta_IOS_PSND,          // Crash Bandicoot Nitro Kart 2 (iOS)
-    meta_BOS_ADP,           // ADP! (Balls of Steel, PC)
-    meta_OTNS_ADP,          // Omikron: The Nomad Soul .adp (PC/DC)
-    meta_EB_SFX,            // Excitebots .sfx
-    meta_EB_SF0,            // Excitebots .sf0
-	meta_PS3_KLBS,          // L@VE ONCE (PS3)
-    meta_PS2_MTAF,          // Metal Gear Solid 3 MTAF
-    meta_PS2_VAG1,          // Metal Gear Solid 3 VAG1
-    meta_PS2_VAG2,          // Metal Gear Solid 3 VAG2
-	meta_TUN,               // LEGO Racers (PC)
-	meta_WPD,               // Shuffle! (PC)
-	meta_MN_STR,            // Mini Ninjas (PC/PS3/WII)
-	meta_MSS,               // Guerilla: ShellShock Nam '67 (PS2/Xbox), Killzone (PS2)
-	meta_PS2_HSF,			// Lowrider (PS2)
-	meta_PS3_IVAG,			// Interleaved VAG files (PS3)
-	meta_PS2_2PFS,			// Konami: Mahoromatic: Moetto - KiraKira Maid-San, GANTZ (PS2)
-	meta_PS2_VBK,           // Disney's Stitch - Experiment 626
-    meta_OTM,               // Otomedius (Arcade)
-    meta_CSTM,              // Nintendo 3DS CSTM (Century Stream)
-    meta_FSTM,              // Nintendo Wii U FSTM (caFe? Stream)
-    meta_3DS_IDSP,          // Nintendo 3DS/Wii U IDSP
-    meta_KT_WIIBGM,         // Koei Tecmo WiiBGM
-    meta_KTSS,              // Koei Tecmo Switch Sound
+    meta_PC_SNDS,           /* Incredibles PC .snds */
+    meta_PS2_WMUS,          /* The Warriors (PS2) */
+    meta_HYPERSCAN_KVAG,    /* Hyperscan KVAG/BVG */
+    meta_IOS_PSND,          /* Crash Bandicoot Nitro Kart 2 (iOS) */
+    meta_BOS_ADP,           /* ADP! (Balls of Steel, PC) */
+    meta_OTNS_ADP,          /* Omikron: The Nomad Soul .adp (PC/DC) */
+    meta_EB_SFX,            /* Excitebots .sfx */
+    meta_EB_SF0,            /* Excitebots .sf0 */
+    meta_PS3_KLBS,          /* L@VE ONCE (PS3) */
+    meta_PS2_MTAF,          /* Metal Gear Solid 3 MTAF */
+    meta_PS2_VAG1,          /* Metal Gear Solid 3 VAG1 */
+    meta_PS2_VAG2,          /* Metal Gear Solid 3 VAG2 */
+    meta_TUN,               /* LEGO Racers (PC) */
+    meta_WPD,               /* Shuffle! (PC) */
+    meta_MN_STR,            /* Mini Ninjas (PC/PS3/WII) */
+    meta_MSS,               /* Guerilla: ShellShock Nam '67 (PS2/Xbox), Killzone (PS2) */
+    meta_PS2_HSF,           /* Lowrider (PS2) */
+    meta_PS3_IVAG,          /* Interleaved VAG files (PS3) */
+    meta_PS2_2PFS,          /* Konami: Mahoromatic: Moetto - KiraKira Maid-San, GANTZ (PS2) */
+    meta_PS2_VBK,           /* Disney's Stitch - Experiment 626 */
+    meta_OTM,               /* Otomedius (Arcade) */
+    meta_CSTM,              /* Nintendo 3DS CSTM (Century Stream) */
+    meta_FSTM,              /* Nintendo Wii U FSTM (caFe? Stream) */
+    meta_3DS_IDSP,          /* Nintendo 3DS/Wii U IDSP */
+    meta_KT_WIIBGM,         /* Koei Tecmo WiiBGM */
+    meta_KTSS,              /* Koei Tecmo Switch Sound */
     meta_MCA,               /* Capcom MCA "MADP" */
     meta_XB3D_ADX,          /* Xenoblade Chronicles 3D ADX */
     meta_HCA,               /* CRI HCA */
@@ -646,7 +646,7 @@ typedef enum {
     meta_EA_SPS,            /* Electronic Arts SPS (Burnout Crash) */
     meta_NGC_VID1,          /* Neversoft .ogg (Gun GC) */
     meta_PC_FLX,            /* Ultima IX PC */
-	meta_MOGG,              /* Harmonix Music Systems MOGG Vorbis */
+    meta_MOGG,              /* Harmonix Music Systems MOGG Vorbis */
 
 #ifdef VGM_USE_VORBIS
     meta_OGG_VORBIS,        /* Ogg Vorbis */
@@ -697,8 +697,8 @@ typedef struct {
         int32_t adpcm_history4_32;
     };
 
-	double adpcm_history1_double;
-	double adpcm_history2_double;
+    double adpcm_history1_double;
+    double adpcm_history2_double;
 
     int adpcm_step_index;       /* for IMA */
     int adpcm_scale;            /* for MS ADPCM */
@@ -775,8 +775,8 @@ typedef struct {
     int codec_endian;               /* little/big endian marker; name is left vague but usually means big endian */
     int codec_version;              /* flag for codecs with minor variations */
 
-    uint8_t xa_channel;				/* XA ADPCM: selected channel */
-    int32_t xa_sector_length;		/* XA ADPCM: XA block */
+    uint8_t xa_channel;             /* XA ADPCM: selected channel */
+    int32_t xa_sector_length;       /* XA ADPCM: XA block */
     uint8_t xa_headerless;          /* XA ADPCM: headerless XA */
     int8_t xa_get_high_nibble;      /* XA ADPCM: mono/stereo nibble selection (XA state could be simplified) */
 
@@ -784,7 +784,7 @@ typedef struct {
 
     void * start_vgmstream;         /* a copy of the VGMSTREAM as it was at the beginning of the stream (for AAX/AIX/SCD) */
 
-	/* Data the codec needs for the whole stream. This is for codecs too
+    /* Data the codec needs for the whole stream. This is for codecs too
      * different from vgmstream's structure to be reasonably shoehorned into
      * using the ch structures.
      * Note also that support must be added for resetting, looping and
@@ -983,10 +983,10 @@ typedef struct {
 
 #ifdef VGM_USE_MAIATRAC3PLUS
 typedef struct {
-	sample *buffer;
-	int channels;
-	int samples_discard;
-	void *handle;
+    sample *buffer;
+    int channels;
+    int samples_discard;
+    void *handle;
 } maiatrac3plus_codec_data;
 #endif
 
@@ -1178,22 +1178,22 @@ typedef struct {
 
 #ifdef VGM_USE_MP4V2
 typedef struct {
-	STREAMFILE *streamfile;
-	uint64_t start;
-	uint64_t offset;
-	uint64_t size;
+    STREAMFILE *streamfile;
+    uint64_t start;
+    uint64_t offset;
+    uint64_t size;
 } mp4_streamfile;
 
 #ifdef VGM_USE_FDKAAC
 typedef struct {
-	mp4_streamfile if_file;
-	MP4FileHandle h_mp4file;
-	MP4TrackId track_id;
-	unsigned long sampleId, numSamples;
-	UINT codec_init_data_size;
-	HANDLE_AACDECODER h_aacdecoder;
-	unsigned int sample_ptr, samples_per_frame, samples_discard;
-	INT_PCM sample_buffer[( (6) * (2048)*4 )];
+    mp4_streamfile if_file;
+    MP4FileHandle h_mp4file;
+    MP4TrackId track_id;
+    unsigned long sampleId, numSamples;
+    UINT codec_init_data_size;
+    HANDLE_AACDECODER h_aacdecoder;
+    unsigned int sample_ptr, samples_per_frame, samples_discard;
+    INT_PCM sample_buffer[( (6) * (2048)*4 )];
 } mp4_aac_codec_data;
 #endif
 #endif

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -934,7 +934,6 @@ typedef struct {
     size_t current_size_target; /* max data, until something happens */
     size_t decode_to_discard;  /* discard from this stream only (for EALayer3 or AWC) */
 
-
 } mpeg_custom_stream;
 
 typedef struct {
@@ -992,7 +991,18 @@ typedef struct {
 #endif
 
 #ifdef VGM_USE_ATRAC9
+
+/* custom ATRAC9 modes */
+typedef enum {
+    ATRAC9_DEFAULT = 0, /* ATRAC9 standard */
+    ATRAC9_XVAG,        /* Sony XVAG: interleaved subsongs, Vita multichannel interleaves 2ch xN superframes */
+  //ATRAC9_FSB,         /* FMOD FSB: Vita multichannel interleaves 2ch xN superframes */
+  //ATRAC9_EATRAX,      /* EA EATrax: buffered ATRAC9 in SPS blocks (superframes can be split between blocks) */
+} atrac9_custom_t;
+
 typedef struct {
+    atrac9_custom_t type;
+
     int channels; /* to detect weird multichannel */
     uint32_t config_data; /* ATRAC9 config header */
     int encoder_delay; /* initial samples to discard */

--- a/test/Makefile.autotools.am
+++ b/test/Makefile.autotools.am
@@ -1,4 +1,4 @@
-## audacious-vgmstream automake script
+## vgmstream autotools script
 
 bin_PROGRAMS = vgmstream-cli
 
@@ -7,7 +7,7 @@ bin_PROGRAMS += vgmstream123
 endif
 
 AM_CFLAGS = -I$(top_builddir) -I$(top_srcdir) -I$(top_srcdir)/ext_includes/ $(AO_CFLAGS)
-AM_MAKEFLAGS = -f Makefile.audacious
+AM_MAKEFLAGS = -f Makefile.autotools
 
 vgmstream_cli_SOURCES = test.c
 vgmstream_cli_LDADD   = ../src/libvgmstream.la

--- a/test/test.c
+++ b/test/test.c
@@ -33,7 +33,7 @@ static void usage(const char * name) {
     fprintf(stderr,"vgmstream test decoder " VERSION " " __DATE__ "\n"
           "Usage: %s [-o outfile.wav] [options] infile\n"
           "Options:\n"
-          "    -o outfile.wav: name of output .wav file, default is dump.wav\n"
+          "    -o outfile.wav: name of output .wav file, default is infile.wav\n"
           "    -l loop count: loop count, default 2.0\n"
           "    -f fade time: fade time (seconds) after N loops, default 10.0\n"
           "    -d fade delay: fade delay (seconds, default 0.0\n"
@@ -67,6 +67,7 @@ int main(int argc, char ** argv) {
     char * infilename = NULL;
     char * outfilename = NULL;
     char * outfilename_reset = NULL;
+    char outfilename_internal[PATH_LIMIT];
     int ignore_loop = 0;
     int force_loop = 0;
     int really_force_loop = 0;
@@ -228,8 +229,12 @@ int main(int argc, char ** argv) {
         outfile = stdout;
     }
     else if (!print_metaonly) {
-        if (!outfilename)
-            outfilename = "dump.wav";
+        if (!outfilename) {
+            strcpy(outfilename_internal, infilename);
+            strcat(outfilename_internal, ".wav");
+            outfilename = outfilename_internal;
+        }
+
         outfile = fopen(outfilename,"wb");
         if (!outfile) {
             fprintf(stderr,"failed to open %s for output\n",outfilename);

--- a/unbootstrap
+++ b/unbootstrap
@@ -1,4 +1,4 @@
 #!/bin/sh
-# audacious-vgmstream script - reverses the actions of bootstrap
+# vgmstream autotools script - reverses the actions of bootstrap
 
-rm -rf configure AUTHORS compile depcomp ChangeLog config.guess ltmain.sh README config.sub autom4te.cache Makefile.audacious.in INSTALL missing NEWS aclocal.m4 install-sh audacious/config.h.in audacious/main.loT audacious/Makefile.audacious.in src/Makefile.audacious.in src/coding/Makefile.audacious.in src/meta/Makefile.audacious.in src/layout/Makefile.audacious.in test/Makefile.audacious.in
+rm -rf configure AUTHORS compile depcomp ChangeLog config.guess ltmain.sh README config.sub autom4te.cache Makefile.autotools.in INSTALL missing NEWS aclocal.m4 install-sh audacious/config.h.in audacious/main.loT audacious/Makefile.autotools.in src/Makefile.autotools.in src/coding/Makefile.autotools.in src/meta/Makefile.autotools.in src/layout/Makefile.autotools.in test/Makefile.autotools.in


### PR DESCRIPTION
- Use infile.wav as default instead of dump.wav for test.exe
- Fix FSB5 v0
- Add .kvs extension [Atelier Sophie (PC)]
- Add extended PS-ADPCM table [inFamous (PS3)]
- Add ATRAC9 decoder
- (dev) renamed stuff

ATRAC9 now works with @Thealexbarney's [libatrac9 library](https://github.com/Thealexbarney/LibAtrac9) (lib will be tuned up later but API shouldn't change).
Note that his library API's isn't 1:1 vs Sony's (for the greater good I think).

Please add if you can, or I can PR if you prefer (as a DLL or the .c in ext_libs/libatrac9 maybe?).
