### PR TITLE
A small fix for Android. 

### DIFF
--- a/src/streamfile.h
+++ b/src/streamfile.h
@@ -15,8 +15,11 @@
 #include <sys/types.h>
 #include "streamtypes.h"
 #include "util.h"
+#if defined(ANDROID)
+#include <unistd.h>
+#endif
 
-#if defined(__MSVCRT__) || defined(_MSC_VER)
+#if (defined(__MSVCRT__) || defined(_MSC_VER)) && !defined(ANDROID)
 #include <io.h>
 #define fseeko fseek
 #define ftello ftell


### PR DESCRIPTION
The function in streamfile.c line 164 (open_stdio) was behaving strange on Android, most likely due to those defines in streamfile.h starting at line 19.

Songs from this set fails to play without the fix: Bionicle Heroes (2006-11-14)(Traveller's Tales)(Eidos) and possibly some others too. 