### PR TITLE
Fixes for Switch Opus reading

### DIFF
--- a/src/coding/ffmpeg_decoder_utils_switch_opus.c
+++ b/src/coding/ffmpeg_decoder_utils_switch_opus.c
@@ -169,7 +169,7 @@ size_t switch_opus_get_samples(off_t offset, size_t data_size, int sample_rate, 
         uint8_t buf[4];
         size_t block_size = read_32bitBE(offset, streamFile);
 
-        read_streamfile(buf, offset+4, 4, streamFile);
+        read_streamfile(buf, offset+8, 4, streamFile);
         num_samples += get_opus_samples_per_frame(buf, sample_rate);
 
         offset += 0x08 + block_size;


### PR DESCRIPTION
- Fixes getting the sample count from Nintendo Switch Opus streams. See the commit message for details.
- Read the pre-sample count from Switch Opus headers.

~~Try and make sure the skip samples are set when using ffmpeg. The value is almost always put in initial_padding.~~