### PR TITLE
Android change for streamfile

### DIFF
--- a/src/streamfile.c
+++ b/src/streamfile.c
@@ -168,7 +168,7 @@ static STREAMFILE *open_stdio(STDIOSTREAMFILE *streamFile,const char * const fil
 
     if (!filename)
         return NULL;
-
+#if !defined (__ANDROID__)
     // if same name, duplicate the file pointer we already have open
     if (!strcmp(streamFile->name,filename)) {
         if (((newfd = dup(fileno(streamFile->infile))) >= 0) &&
@@ -182,6 +182,7 @@ static STREAMFILE *open_stdio(STDIOSTREAMFILE *streamFile,const char * const fil
             fclose(newfile);
         }
     }
+#endif    
     // a normal open, open a new file
     return open_stdio_streamfile_buffer(filename,buffersize);
 }

--- a/src/streamfile.h
+++ b/src/streamfile.h
@@ -15,11 +15,8 @@
 #include <sys/types.h>
 #include "streamtypes.h"
 #include "util.h"
-#if defined(ANDROID)
-#include <unistd.h>
-#endif
 
-#if (defined(__MSVCRT__) || defined(_MSC_VER)) && !defined(ANDROID)
+#if defined(__MSVCRT__) || defined(_MSC_VER)
 #include <io.h>
 #define fseeko fseek
 #define ftello ftell


### PR DESCRIPTION
Revert back the previous Android change. It seems that the 'dup' is not working perfectly with unistd.h either. The open_stdio func seems to work better by using the default path.