### PR TITLE
Fix ATRAC9 regression

### DIFF
--- a/src/meta/riff.c
+++ b/src/meta/riff.c
@@ -198,6 +198,7 @@ static int read_fmt(int big_endian, STREAMFILE * streamFile, off_t current_chunk
                 fmt->block_size = (bztmp & 0x3FF) * 8 + 8; //should match fmt->block_size
 #elif defined(VGM_USE_FFMPEG)
                 fmt->coding_type = coding_FFmpeg;
+                break;
 #else
                 goto fail;
 #endif
@@ -210,12 +211,13 @@ static int read_fmt(int big_endian, STREAMFILE * streamFile, off_t current_chunk
                 read_32bitBE(current_chunk+0x2c,streamFile) == 0x4F8C836C) {
 #ifdef VGM_USE_ATRAC9
                 fmt->coding_type = coding_ATRAC9;
+                break;
 #else
                 goto fail;
 #endif
             }
 
-            goto fail;
+            goto fail; /* unknown GUID */
 
         default:
             goto fail;


### PR DESCRIPTION
* Fix ATRAC9 regression 

(seems appveyor is being naughty once again, or maybe the foobar SDK changed somehow?)

ALSO! Please update libatrac9.dll, as there was a minor regression too that makes a few files decode incorrectly [>>](https://github.com/Thealexbarney/LibAtrac9/commit/91fd5507e3b1ebc88572cda68c2b7e143cb2155e)