### PR TITLE
Fix DownloadFile for TLS connections

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -5,6 +5,9 @@ Param(
     [string]$Task
 )
 
+# https://stackoverflow.com/a/41618979/9919772
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 $solution = "vgmstream_full.sln"
 $vswhere = "dependencies/vswhere.exe"
 $config = "/p:Configuration=Release"


### PR DESCRIPTION
On Windows 10, I was getting the following errors when running `init-build.bat`:

```
vgmstream>init-build.bat

powershell -ExecutionPolicy Bypass -NoProfile -File .\build.ps1 Init
Downloading https://github.com/kode54/fdk-aac/archive/master.zip
Exception calling "DownloadFile" with "2" argument(s): "The request was aborted: Could not create SSL/TLS secure
channel."
At .\vgmstream\build.ps1:42 char:5
+     $wc.Downloadfile($uri, $outfile)
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException

Downloading https://github.com/kode54/qaac/archive/master.zip
Exception calling "DownloadFile" with "2" argument(s): "The request was aborted: Could not create SSL/TLS secure
channel."
At .\vgmstream\build.ps1:42 char:5
+     $wc.Downloadfile($uri, $outfile)
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException

...

```

This PR fixes the errors by setting the appropriate PowerShell TLS SecurityProtocol. See https://stackoverflow.com/a/41618979/9919772