### PR TITLE
If a file has no extension, try to play it anyway

### DIFF
--- a/fb2k/foo_vgmstream.cpp
+++ b/fb2k/foo_vgmstream.cpp
@@ -341,6 +341,11 @@ bool input_vgmstream::g_is_our_path(const char * p_path,const char * p_extension
             return 1;
     }
 
+    if (strlen(p_extension) <= 0) {
+        // Last Of Us speech files have no file extension
+        return 1;
+    }
+
     return 0;
 }
 

--- a/src/meta/xvag.c
+++ b/src/meta/xvag.c
@@ -18,10 +18,6 @@ VGMSTREAM * init_vgmstream_xvag(STREAMFILE *streamFile) {
     off_t first_offset = 0x20;
     size_t chunk_size, stream_size;
 
-    /* check extension, case insensitive */
-    if (!check_extensions(streamFile,"xvag"))
-        goto fail;
-
     /* check header */
     if (read_32bitBE(0x00,streamFile) != 0x58564147) /* "XVAG" */
         goto fail;

--- a/src/meta/xvag.c
+++ b/src/meta/xvag.c
@@ -18,6 +18,10 @@ VGMSTREAM * init_vgmstream_xvag(STREAMFILE *streamFile) {
     off_t first_offset = 0x20;
     size_t chunk_size, stream_size;
 
+    /* check extension, case insensitive */
+    if (!check_extensions(streamFile,"xvag,"))
+        goto fail;
+
     /* check header */
     if (read_32bitBE(0x00,streamFile) != 0x58564147) /* "XVAG" */
         goto fail;


### PR DESCRIPTION
This allows fb2k to play Last Of Us (PS3) speech files, which have no
file extension.