### PR TITLE
STR, MUS, exts

### DIFF
--- a/fb2k/foo_vgmstream.cpp
+++ b/fb2k/foo_vgmstream.cpp
@@ -21,6 +21,7 @@ extern "C" {
 #ifndef VERSION
 #include "../version.h"
 #endif
+
 #ifndef VERSION
 #define PLUGIN_VERSION  __DATE__
 #else
@@ -144,6 +145,8 @@ void input_vgmstream::get_info(t_uint32 p_subsong, file_info & p_info, abort_cal
     if (get_subsong_count() > 1) {
         p_info.meta_set("TITLE",temp);
     }
+
+    p_info.info_set("vgmstream version",PLUGIN_VERSION);
 
     p_info.info_set_int("samplerate", samplerate);
     p_info.info_set_int("channels", channels);

--- a/src/formats.c
+++ b/src/formats.c
@@ -909,7 +909,7 @@ static const meta_info meta_info_list[] = {
         {meta_X360_TRA,             "Terminal Reality .TRA raw header"},
         {meta_PS2_VGS,              "Princess Soft VGS header"},
         {meta_PS2_IAB,              "Runtime .IAB header"},
-        {meta_PS2_STRLR,            "STR L/R header"},
+        {meta_PS2_STRLR,            "The Bouncer STR header"},
         {meta_LSF_N1NJ4N,           ".lsf !n1nj4n header"},
         {meta_VAWX,                 "feelplus VAWX header"},
         {meta_PC_SNDS,              "assumed Heavy Iron IMA by .snds extension"},

--- a/src/formats.c
+++ b/src/formats.c
@@ -1,13 +1,16 @@
 #include "vgmstream.h"
 
-//#define VGM_REGISTER_TYPE(extension) ...
-//#define VGM_REGISTER_TYPE_COMMON(extension) ... /* for common extensions like aiff */
 
+/* defines the list of accepted extensions. vgmstream doesn't use it internally so it's here
+ * to inform plugins that need it. Common extensions are commented out to avoid stealing them. */
 
-/* some extensions could be #ifdef but no really needed */
+/* some extensions require external libraries and could be #ifdef, no really needed */
 /* some formats marked as "not parsed" mean they'll go through FFmpeg, the header/extension is not parsed */
 
+
 static const char* extension_list[] = {
+    //"", /* vgmstream can plays extensionless files too, but plugins must accept them manually */
+
     "04sw",
     "2dx9",
     "2pfs",
@@ -437,7 +440,7 @@ static const char* extension_list[] = {
     "zsd",
     "zwdsp",
 
-    "vgmstream"
+    "vgmstream" /* fake extension, catch-all for FFmpeg/txth/etc */
 
     //, NULL //end mark
 };

--- a/src/formats.c
+++ b/src/formats.c
@@ -38,6 +38,7 @@ static const char* extension_list[] = {
     "al2",
     "amts", //fake extension/header id for .stm (to be removed)
     "ao", //txth/reserved [Cloudphobia (PC)]
+    "apc", //txth/reserved [MegaRace 3 (PC)]
     "as4",
     "asd",
     "asf",
@@ -367,6 +368,7 @@ static const char* extension_list[] = {
     "v0",
     //"v1", //dual channel with v0
     "vag",
+    "vai", //txth/reserved [Ratatouille (GC)]
     "vas",
     "vawx",
     "vb",

--- a/src/formats.c
+++ b/src/formats.c
@@ -1025,6 +1025,7 @@ static const meta_info meta_info_list[] = {
         {meta_OGG_GWM,              "Ogg Vorbis (GWM header)"},
         {meta_DSP_SADF,             "Procyon Studio SADF header"},
         {meta_H4M,                  "Hudson HVQM4 header"},
+        {meta_OGG_MUS,              "Ogg Vorbis (MUS header)"},
 
 #ifdef VGM_USE_FFMPEG
         {meta_FFmpeg,               "FFmpeg supported file format"},

--- a/src/layout/blocked_ps2_strlr.c
+++ b/src/layout/blocked_ps2_strlr.c
@@ -1,19 +1,17 @@
 #include "layout.h"
 #include "../vgmstream.h"
 
-/* set up for the block at the given offset */
+/* The Bouncer STRx blocks, one block per channel when stereo */
 void block_update_ps2_strlr(off_t block_offset, VGMSTREAM * vgmstream) {
+    STREAMFILE* streamFile = vgmstream->ch[0].streamfile;
     int i;
 
-	vgmstream->current_block_offset = block_offset;
-	vgmstream->current_block_size = read_32bitLE(
-			vgmstream->current_block_offset+0x4,
-			vgmstream->ch[0].streamfile)*2;
-	vgmstream->next_block_offset = vgmstream->current_block_offset+vgmstream->current_block_size+0x40;
-	//vgmstream->current_block_size/=vgmstream->channels;
+    vgmstream->current_block_offset = block_offset;
+    vgmstream->current_block_size = read_32bitLE(block_offset+0x04,streamFile); /* can be smaller than 0x800 */
+    vgmstream->next_block_offset = block_offset + 0x800*vgmstream->channels;
+    /* 0x08: number of remaning blocks, 0x10: some id/size? (shared in all blocks) */
 
-	for (i=0;i<vgmstream->channels;i++) {
-        vgmstream->ch[i].offset = vgmstream->current_block_offset+0x20+(0x800*i);
-		
+    for (i = 0; i < vgmstream->channels; i++) {
+        vgmstream->ch[i].offset = block_offset + 0x20 + 0x800*i;
     }
 }

--- a/src/meta/hca_keys.h
+++ b/src/meta/hca_keys.h
@@ -238,7 +238,13 @@ static const hcakey_info hcakey_list[] = {
         {3201512},      // 000000000030D9E8
 
         // PriPara: All Idol Perfect Stage (Takara Tomy) [Switch]
-		{217735759},      // 000000000CFA624F
+        {217735759},      // 000000000CFA624F
+
+        // Space Invaders Extreme (Taito Corporation, Backbone Entertainment) [PC]
+        {91380310056},              // 0000001546B0E028
+
+        // CR Another God Hades Advent (Universal Entertainment Corporation) [iOS/Android]
+        {64813795},                 // 0000000003DCFAE3
 
 };
 

--- a/src/meta/ps2_strlr.c
+++ b/src/meta/ps2_strlr.c
@@ -1,80 +1,57 @@
 #include "meta.h"
 #include "../layout/layout.h"
-#include "../util.h"
+#include "../coding/coding.h"
 
-/* STR: The Bouncer (PS2) */
+/* STR - The Bouncer (PS2) */
 VGMSTREAM * init_vgmstream_ps2_strlr(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
-    char filename[PATH_LIMIT];
-    int loop_flag = 0;
-	int channel_count;
-    int i;
-	off_t start_offset;
-	
-    /* check extension, case insensitive */
-    streamFile->get_name(streamFile,filename,sizeof(filename));
-    if (strcasecmp("str",filename_extension(filename))) goto fail;
+    int channel_count, loop_flag;
+    off_t start_offset;
 
-#if 0
+
+    /* checks */
+    /* .vs: real extension (from .nam container) , .str: partial header id */
+    if (!check_extensions(streamFile, "vs,str"))
+        goto fail;
+
     /* check header */
-    if (read_32bitBE(0x00,streamFile) != 0x5354524C) /* "STRL" */
+    if (!(read_32bitBE(0x000,streamFile) == 0x5354524C &&   /* "STRL" */
+          read_32bitBE(0x800,streamFile) == 0x53545252) &&  /* "STRR" */
+        read_32bitBE(0x00,streamFile) != 0x5354524D)        /* "STRM" */
         goto fail;
-	if (read_32bitBE(0x00,streamFile) != 0x53545252) /* "STRR" */
-        goto fail;
-#endif
 
-    /* don't hijack Sonic & Sega All Stars Racing X360 (xma) */
-    if (read_32bitBE(0x00,streamFile) == 0x52494646)
-        goto fail; /* "RIFF"*/
-    /* don't hijack Mad Dash Racing (Xbox) */
-    if (read_32bitLE(0x0c,streamFile) == 1
-            && read_32bitLE(0x010,streamFile) == 0
-            && read_32bitLE(0x400,streamFile) == 0
-            && read_32bitLE(0x7f0,streamFile) == 0)
-        goto fail;
 
     loop_flag = 0;
-    channel_count = 2;
-    
-	/* build the VGMSTREAM */
+    channel_count = (read_32bitBE(0x00,streamFile) == 0x5354524D) ? 1 : 2; /* "STRM"=mono (voices) */
+    start_offset = 0x00;
+
+    /* build the VGMSTREAM */
     vgmstream = allocate_vgmstream(channel_count,loop_flag);
     if (!vgmstream) goto fail;
 
-	/* fill in the vital statistics */
-    start_offset = 0x0;
-	vgmstream->channels = channel_count;
-    vgmstream->sample_rate = 48000;
+    vgmstream->sample_rate = 44100;
     vgmstream->coding_type = coding_PSX;
 
     vgmstream->layout_type = layout_blocked_ps2_strlr;
-    //vgmstream->interleave_block_size = read_32bitLE(0xC, streamFile);
     vgmstream->meta_type = meta_PS2_STRLR;
-    
-    /* open the file for reading by each channel */
+
+    if (!vgmstream_open_stream(vgmstream,streamFile,start_offset))
+        goto fail;
+
+    /* calc num_samples */
     {
-        for (i=0;i<channel_count;i++) 
-		{
-            vgmstream->ch[i].streamfile = streamFile->open(streamFile, filename, 0x8000);            
-			if (!vgmstream->ch[i].streamfile) goto fail;
+        vgmstream->next_block_offset = start_offset;
+        do {
+            block_update_ps2_strlr(vgmstream->next_block_offset,vgmstream);
+            vgmstream->num_samples += ps_bytes_to_samples(vgmstream->current_block_size, 1);
         }
+        while (vgmstream->next_block_offset < get_streamfile_size(streamFile));
     }
 
-    /* Calc num_samples */
     block_update_ps2_strlr(start_offset, vgmstream);
-    vgmstream->num_samples=0;
-
-    do
-	{
-		vgmstream->num_samples += vgmstream->current_block_size * 14 / 16;
-        block_update_ps2_strlr(vgmstream->next_block_offset, vgmstream);
-    } while (vgmstream->next_block_offset < get_streamfile_size(streamFile));
-
-    block_update_ps2_strlr(start_offset, vgmstream);
-
     return vgmstream;
 
-    /* clean up anything we may have opened */
 fail:
-    if (vgmstream) close_vgmstream(vgmstream);
+    close_vgmstream(vgmstream);
     return NULL;
 }

--- a/src/meta/ubi_sb.c
+++ b/src/meta/ubi_sb.c
@@ -313,6 +313,7 @@ static int parse_sb_header(ubi_sb_header * sb, STREAMFILE *streamFile) {
         /* ignore non-audio entry (other types seem to have config data) */
         if (read_32bit(offset + 0x04, streamFile) != 0x01)
             continue;
+        //;VGM_LOG("SB at %lx\n", offset);
 
         /* weird case when there is no internal substream ID and just seem to rotate every time type changes, joy */
         if (sb->has_rotating_ids) { /* assumes certain configs can't happen in this case */
@@ -779,6 +780,23 @@ static int config_sb_header_version(ubi_sb_header * sb, STREAMFILE *streamFile) 
 
         return 1;
     }
+#if 0
+    /* Far cry: Instincts - Evolution (2006)(Xbox) */
+    if (sb->version == 0x00170000 && is_sb2) {
+        sb->section1_entry_size = 0x48;
+        sb->section2_entry_size = 0x6c;
+
+        sb->external_flag_offset = 0;
+        sb->num_samples_offset   = 0x28;
+        sb->stream_id_offset     = 0;
+        sb->sample_rate_offset   = 0x3c;
+        sb->channels_offset      = 0x44;
+        sb->stream_type_offset   = 0x48;
+        sb->extra_name_offset    = 0x58;
+
+        return 1;
+    }
+#endif
 
     /* Prince of Persia: Rival Swords (2007)(PSP) */
     if (sb->version == 0x00180005 && is_sb5) {

--- a/src/util.c
+++ b/src/util.c
@@ -2,16 +2,28 @@
 #include "util.h"
 #include "streamtypes.h"
 
-const char * filename_extension(const char * filename) {
-    const char * ext;
+const char * filename_extension(const char * pathname) {
+    const char * filename;
+    const char * extension;
 
-    /* You know what would be nice? strrchrnul().
-     * Instead I have to do it myself. */
-    ext = strrchr(filename,'.');
-    if (ext==NULL) ext=filename+strlen(filename); /* point to null, i.e. an empty string for the extension */
-    else ext=ext+1; /* skip the dot */
+    /* get basename + extension */
+    filename = pathname;
+#if 0
+    //must detect empty extensions in folders with . in the name; not too important and DIR_SEPARATOR could improved
+    filename = strrchr(pathname, DIR_SEPARATOR);
+    if (filename == NULL)
+        filename = pathname; /* pathname has no separators (single filename) */
+    else
+        filename++; /* skip the separator */
+#endif
 
-    return ext;
+    extension = strrchr(filename,'.');
+    if (extension==NULL)
+        extension = filename+strlen(filename); /* point to null, i.e. an empty string for the extension */
+    else
+        extension++; /* skip the dot */
+
+    return extension;
 }
 
 /* unused */

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -679,6 +679,7 @@ typedef enum {
     meta_TA_AAC_VITA,       /* tri-Ace AAC (Judas Code) */
     meta_OGG_GWM,           /* Ogg Vorbis with encryption [Metronomicon (PC)] */
     meta_H4M,               /* Hudson HVQM4 video [Resident Evil 0 (GC), Tales of Symphonia (GC)] */
+    meta_OGG_MUS,           /* Ogg Vorbis with encryption [Redux - Dark Matters (PC)] */
 
 #ifdef VGM_USE_FFMPEG
     meta_FFmpeg,


### PR DESCRIPTION
- Add .mus Ogg [Redux - Dark Matters (PC)]
- Add .vai/apc extensions
- Add hca keys
- Add vgmstream version in foobar's file properties
- Fix The Bouncer .vs (.str)
- Fix some .joe looping jingles
- Allow extensionless files in Winamp [Baten Kaitos 2 (GC)]
