### PR TITLE
vgmstream fix number 2

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -413,6 +413,7 @@ static const char* extension_list[] = {
     "wve",
     "wvs",
 
+    "x",
     "xa",
     "xa2",
     "xa30",

--- a/src/meta/ps2_exst.c
+++ b/src/meta/ps2_exst.c
@@ -24,7 +24,7 @@ VGMSTREAM * init_vgmstream_ps2_exst(STREAMFILE *streamFile) {
 
     /* check extension, case insensitive */
     streamFile->get_name(streamFile,filename,sizeof(filename));
-    if (strcasecmp("sts",filename_extension(filename))) goto fail;
+    if (strcasecmp("x",filename_extension(filename))) goto fail;
 
     /* check EXST Header */
     if (read_32bitBE(0x00,streamFile) != 0x45585354)
@@ -45,12 +45,12 @@ VGMSTREAM * init_vgmstream_ps2_exst(STREAMFILE *streamFile) {
 
     /* Compression Scheme */
     vgmstream->coding_type = coding_PSX;
-    vgmstream->num_samples = (read_32bitLE(0x14,streamFile)*0x400)/16*28;
+    vgmstream->num_samples = ps_bytes_to_samples((read_32bitLE(0x14,streamFile)*0x400));
 
     /* Get loop point values */
     if(vgmstream->loop_flag) {
-        vgmstream->loop_start_sample = (read_32bitLE(0x10,streamFile)*0x400)/16*28;
-        vgmstream->loop_end_sample = (read_32bitLE(0x14,streamFile)*0x400)/16*28;
+        vgmstream->loop_start_sample = ps_bytes_to_samples((read_32bitLE(0x10,streamFile)*0x400));
+        vgmstream->loop_end_sample = ps_bytes_to_samples((read_32bitLE(0x14,streamFile)*0x400));
     }
 
     vgmstream->interleave_block_size = 0x400;


### PR DESCRIPTION
adjust ps2_exst.c code because all this shit is just wrong
i just found out through Ape Escape 3's data that the EXST files do exist this way, albeit with a legit manner and with the .x extension intact
so that's why i made sure that vgmstream only plays merged EXST files with the "x" extension - i know it breaks some existing rips but it's better than nothing

by the way, the actual .sts files are stand-alone EXST headers that only serve to give in some general info to the accompanying .int file(if there is any) - due to their scattered nature however(although this must be 100% wrong but i've seen it happen most of the time in those rare PS2 games anyway) i have only seen one game(Gacha Mecha Stadium Saru Battle) in which it has both .sts and .int file in place, and only one of them at that too

here are the samples by the way(.x files only)
[https://www.sendspace.com/file/kvhb0w](url)