### PR TITLE
Add looping for Air (Android) Oggs and .lflac ext for kicks

### DIFF
--- a/src/formats.c
+++ b/src/formats.c
@@ -185,6 +185,7 @@ static const char* extension_list[] = {
     "laac", //fake extension, for AAC (tri-Ace/FFmpeg)
     "lac3", //fake extension, for AC3
     "leg",
+    "lflac", //fake extension, FFmpeg, not parsed, use with .pos pair for fun
     "lmp4", //fake extension, for MP4s
     "logg", //fake extension, for OGGs
     "lopus", //fake extension, for OPUS

--- a/src/meta/ogg_vorbis.c
+++ b/src/meta/ogg_vorbis.c
@@ -546,6 +546,11 @@ VGMSTREAM * init_vgmstream_ogg_vorbis_callbacks(STREAMFILE *streamFile, ov_callb
                     loop_length_found = 1;
                 }
 			}
+            else if (strstr(user_comment, "omment=") == user_comment) { /* Air (Android) */
+                sscanf(strstr(user_comment, "=LOOPSTART=") + 11, "%d,LOOPEND=%d", &loop_start, &loop_end);
+                loop_flag = 1;
+                loop_end_found = 1;
+            }
 
             //;VGM_LOG("OGG: user_comment=%s\n", user_comment);
         }


### PR DESCRIPTION
Add loop support for Air (Android) Oggs. Add .lflac extension for use with .pos