### PR TITLE
Workaround MSVC fseek/fread bug

### DIFF
--- a/src/streamfile.c
+++ b/src/streamfile.c
@@ -76,6 +76,17 @@ static size_t read_stdio(STDIOSTREAMFILE *streamfile,uint8_t * dest, off_t offse
         else
             length_to_read = length;
 
+#ifdef _MSC_VER
+        /* Workaround a bug that appears when compiling witn MSVC.
+        * This bug is dertiministic and seemingly appears randomly
+        * after seeking.
+        * It results in fread returning data from the wrong
+        * area of the file.
+        * HPS is one format that is almost always affected
+        * by this.  */
+        fseek(streamfile->infile, ftell(streamfile->infile), SEEK_SET);
+#endif
+
         /* fill the buffer */
         length_read = fread(streamfile->buffer,sizeof(uint8_t),streamfile->buffersize,streamfile->infile);
         streamfile->validsize = length_read;


### PR DESCRIPTION
The MSVC runtime has a bug that results in data being returned from the wrong part of the file when using `fread` after an `fseek`.

The bug can be reproduced by decoding most HPS files with the CLI program. In the resulting output the right channel will cut out and the left channel will begin playing alternating audio from both channels.

Doing an `fseek(FILE, ftell(FILE));` works around the issue in the cases I've seen.