### PR TITLE
vgmstream fix number 4

### DIFF
--- a/src/meta/ps2_ads.c
+++ b/src/meta/ps2_ads.c
@@ -17,8 +17,9 @@ VGMSTREAM * init_vgmstream_ps2_ads(STREAMFILE *streamFile) {
     /* .ads: actual extension
      * .ss2: demuxed videos (fake?)
      * .pcm: Taisho Mononoke Ibunroku (PS2)
-     * .adx: Armored Core 3 (PS2) */
-    if (!check_extensions(streamFile, "ads,ss2,pcm,adx"))
+     * .adx: Armored Core 3 (PS2)
+     * [no actual extension]: MotoGP (PS2) */
+    if (!check_extensions(streamFile, "ads,ss2,pcm,adx,"))
         goto fail;
 
     if (read_32bitBE(0x00,streamFile) != 0x53536864 &&  /* "SShd" */

--- a/src/meta/ps2_vpk.c
+++ b/src/meta/ps2_vpk.c
@@ -42,7 +42,7 @@ VGMSTREAM * init_vgmstream_ps2_vpk(STREAMFILE *streamFile) {
         vgmstream->loop_end_sample = vgmstream->num_samples;
     }
 
-    vgmstream->interleave_block_size = read_32bitLE(0x0C,streamFile)/vgmstream->channels;
+    vgmstream->interleave_block_size = read_32bitLE(0x0C,streamFile)/2;
     vgmstream->layout_type = layout_interleave;
     vgmstream->meta_type = meta_PS2_VPK;
 


### PR DESCRIPTION
this pull request adds extension-less support to the SShd/SSbd format as seen in MotoGP by Namco

samples to test are [here](https://www.sendspace.com/file/lanvtp)