### PR TITLE
eaopus lse bnk

### DIFF
--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -280,7 +280,7 @@ ffmpeg_codec_data * init_ffmpeg_switch_opus(STREAMFILE *streamFile, off_t start_
 ffmpeg_codec_data * init_ffmpeg_ue4_opus(STREAMFILE *streamFile, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
 ffmpeg_codec_data * init_ffmpeg_ea_opus(STREAMFILE *streamFile, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
 
-size_t switch_opus_get_samples(off_t offset, size_t data_size, int sample_rate, STREAMFILE *streamFile);
+size_t switch_opus_get_samples(off_t offset, size_t data_size, STREAMFILE *streamFile);
 
 size_t switch_opus_get_encoder_delay(off_t offset, STREAMFILE *streamFile);
 size_t ue4_opus_get_encoder_delay(off_t offset, STREAMFILE *streamFile);

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -278,6 +278,7 @@ void ffmpeg_set_skip_samples(ffmpeg_codec_data * data, int skip_samples);
 /* ffmpeg_decoder_custom_opus.c (helper-things) */
 ffmpeg_codec_data * init_ffmpeg_switch_opus(STREAMFILE *streamFile, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
 ffmpeg_codec_data * init_ffmpeg_ue4_opus(STREAMFILE *streamFile, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
+ffmpeg_codec_data * init_ffmpeg_ea_opus(STREAMFILE *streamFile, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
 size_t ffmpeg_make_opus_header(uint8_t * buf, int buf_size, int channels, int skip, int sample_rate);
 size_t switch_opus_get_samples(off_t offset, size_t data_size, int sample_rate, STREAMFILE *streamFile);
 size_t ue4_opus_get_samples(off_t offset, size_t data_size, int sample_rate, STREAMFILE *streamFile);

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -279,9 +279,12 @@ void ffmpeg_set_skip_samples(ffmpeg_codec_data * data, int skip_samples);
 ffmpeg_codec_data * init_ffmpeg_switch_opus(STREAMFILE *streamFile, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
 ffmpeg_codec_data * init_ffmpeg_ue4_opus(STREAMFILE *streamFile, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
 ffmpeg_codec_data * init_ffmpeg_ea_opus(STREAMFILE *streamFile, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate);
-size_t ffmpeg_make_opus_header(uint8_t * buf, int buf_size, int channels, int skip, int sample_rate);
+
 size_t switch_opus_get_samples(off_t offset, size_t data_size, int sample_rate, STREAMFILE *streamFile);
-size_t ue4_opus_get_samples(off_t offset, size_t data_size, int sample_rate, STREAMFILE *streamFile);
+
+size_t switch_opus_get_encoder_delay(off_t offset, STREAMFILE *streamFile);
+size_t ue4_opus_get_encoder_delay(off_t offset, STREAMFILE *streamFile);
+size_t ea_opus_get_encoder_delay(off_t offset, STREAMFILE *streamFile);
 
 #endif
 

--- a/src/coding/ffmpeg_decoder_custom_opus.c
+++ b/src/coding/ffmpeg_decoder_custom_opus.c
@@ -468,7 +468,7 @@ static size_t opus_get_packet_samples(const uint8_t * buf, int len) {
     return opus_packet_get_nb_frames(buf, len) * opus_packet_get_samples_per_frame(buf, 48000);
 }
 
-static size_t custom_opus_get_samples(off_t offset, size_t data_size, int sample_rate, STREAMFILE *streamFile, opus_type_t type) {
+static size_t custom_opus_get_samples(off_t offset, size_t data_size, STREAMFILE *streamFile, opus_type_t type) {
     size_t num_samples = 0;
     off_t end_offset = offset + data_size;
 
@@ -508,8 +508,8 @@ static size_t custom_opus_get_samples(off_t offset, size_t data_size, int sample
     return num_samples;
 }
 
-size_t switch_opus_get_samples(off_t offset, size_t data_size, int sample_rate, STREAMFILE *streamFile) {
-    return custom_opus_get_samples(offset, data_size, sample_rate, streamFile, OPUS_SWITCH);
+size_t switch_opus_get_samples(off_t offset, size_t data_size, STREAMFILE *streamFile) {
+    return custom_opus_get_samples(offset, data_size, streamFile, OPUS_SWITCH);
 }
 
 

--- a/src/coding/ffmpeg_decoder_custom_opus.c
+++ b/src/coding/ffmpeg_decoder_custom_opus.c
@@ -17,7 +17,7 @@ static size_t make_oggs_first(uint8_t * buf, int buf_size, int channels, int ski
 static size_t make_oggs_page(uint8_t * buf, int buf_size, size_t data_size, int page_sequence, int granule);
 static size_t opus_get_packet_samples(const uint8_t * buf, int len);
 
-typedef enum { OPUS_SWITCH, OPUS_UE4 } opus_type_t;
+typedef enum { OPUS_SWITCH, OPUS_UE4, OPUS_EA } opus_type_t;
 typedef struct {
     /* config */
     opus_type_t type;
@@ -98,6 +98,10 @@ static size_t opus_io_read(STREAMFILE *streamfile, uint8_t *dest, off_t offset, 
                     break;
                 case OPUS_UE4:
                     data_size = (uint16_t)read_16bitLE(data->physical_offset, streamfile);
+                    skip_size = 0x02;
+                    break;
+                case OPUS_EA:
+                    data_size = (uint16_t)read_16bitBE(data->physical_offset, streamfile);
                     skip_size = 0x02;
                     break;
                 default:
@@ -182,6 +186,10 @@ static size_t opus_io_size(STREAMFILE *streamfile, opus_io_data* data) {
                 break;
             case OPUS_UE4:
                 data_size = (uint16_t)read_16bitLE(physical_offset, streamfile);
+                skip_size = 0x02;
+                break;
+            case OPUS_EA:
+                data_size = (uint16_t)read_16bitBE(physical_offset, streamfile);
                 skip_size = 0x02;
                 break;
             default:
@@ -483,6 +491,10 @@ static size_t custom_opus_get_samples(off_t offset, size_t data_size, int sample
                 data_size = (uint16_t)read_16bitLE(offset, streamFile);
                 skip_size = 0x02;
                 break;
+            case OPUS_EA:
+                data_size = (uint16_t)read_16bitBE(offset, streamFile);
+                skip_size = 0x02;
+                break;
             default:
                 return 0;
         }
@@ -532,6 +544,10 @@ ffmpeg_codec_data * init_ffmpeg_switch_opus(STREAMFILE *streamFile, off_t start_
 
 ffmpeg_codec_data * init_ffmpeg_ue4_opus(STREAMFILE *streamFile, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate) {
     return init_ffmpeg_custom_opus(streamFile, start_offset, data_size, channels, skip, sample_rate, OPUS_UE4);
+}
+
+ffmpeg_codec_data * init_ffmpeg_ea_opus(STREAMFILE *streamFile, off_t start_offset, size_t data_size, int channels, int skip, int sample_rate) {
+    return init_ffmpeg_custom_opus(streamFile, start_offset, data_size, channels, skip, sample_rate, OPUS_EA);
 }
 
 #endif

--- a/src/coding/g719_decoder.c
+++ b/src/coding/g719_decoder.c
@@ -2,14 +2,14 @@
 #include <g719.h>
 
 #ifdef VGM_USE_G719
-#define G719_MAX_FRAME_SIZE 0x1000 /* arbitrary max (samples per frame seems to always be 960) */
+#define G719_MAX_CODES ((1280/8)) /* in int16, so max frame size is (value/8)*2 (0xF0=common, 0x140=decoder max 2560b, rare) */
 
 
 g719_codec_data *init_g719(int channel_count, int frame_size) {
     int i;
     g719_codec_data *data = NULL;
 
-    if (frame_size / sizeof(int16_t) > G719_MAX_FRAME_SIZE)
+    if (frame_size / sizeof(int16_t) > G719_MAX_CODES)
         goto fail;
 
     data = calloc(channel_count, sizeof(g719_codec_data)); /* one decoder per channel */
@@ -18,10 +18,6 @@ g719_codec_data *init_g719(int channel_count, int frame_size) {
     for (i = 0; i < channel_count; i++) {
         data[i].handle = g719_init(frame_size); /* Siren 22 == 22khz bandwidth */
         if (!data[i].handle) goto fail;
-
-        /* known values: 0xF0=common (sizeof(int16) * 960/8), 0x140=rare (sizeof(int16) * 1280/8) */
-        data[i].code_buffer = malloc(sizeof(int16_t) * frame_size);
-        if (!data[i].code_buffer) goto fail;
     }
 
     return data;
@@ -45,8 +41,10 @@ void decode_g719(VGMSTREAM * vgmstream, sample * outbuf, int channelspacing, int
     int i;
 
     if (0 == vgmstream->samples_into_block) {
-        read_streamfile((uint8_t*)ch_data->code_buffer, ch->offset, vgmstream->interleave_block_size, ch->streamfile);
-        g719_decode_frame(ch_data->handle, ch_data->code_buffer, ch_data->buffer);
+        int16_t code_buffer[G719_MAX_CODES];
+
+        read_streamfile((uint8_t*)code_buffer, ch->offset, vgmstream->interleave_block_size, ch->streamfile);
+        g719_decode_frame(ch_data->handle, code_buffer, ch_data->buffer);
     }
 
     for (i = 0; i < samples_to_do; i++) {
@@ -70,7 +68,6 @@ void free_g719(g719_codec_data * data, int channels) {
 
     for (i = 0; i < channels; i++) {
         g719_free(data[i].handle);
-        free(data[i].code_buffer);
     }
     free(data);
 }

--- a/src/formats.c
+++ b/src/formats.c
@@ -199,6 +199,7 @@ static const char* extension_list[] = {
     "lpcm",
     "lpk",
     "lps",
+    "lse",
     "lsf",
     "lstm", //fake extension, for STMs
     "lwav", //fake extension, for WAVs
@@ -1095,6 +1096,7 @@ static const meta_info meta_info_list[] = {
         {meta_NXA,                  "Entergram NXA header"},
         {meta_ADPCM_CAPCOM,         "Capcom .ADPCM header"},
         {meta_UE4OPUS,              "Epic Games UE4OPUS header"},
+        {meta_OGG_LSE,              "Ogg Vorbis (LSE header)"},
 
 };
 

--- a/src/meta/bnk_sony.c
+++ b/src/meta/bnk_sony.c
@@ -11,7 +11,7 @@ VGMSTREAM * init_vgmstream_bnk_sony(STREAMFILE *streamFile) {
     size_t stream_size, interleave = 0;
     off_t sblk_offset, data_offset;
     size_t data_size;
-    int channel_count = 0, loop_flag, sample_rate, version;
+    int channel_count = 0, loop_flag, sample_rate, parts, version;
     int loop_start = 0, loop_end = 0;
     uint32_t atrac9_info = 0;
 
@@ -25,11 +25,11 @@ VGMSTREAM * init_vgmstream_bnk_sony(STREAMFILE *streamFile) {
     if (!check_extensions(streamFile, "bnk"))
         goto fail;
 
-    if (read_32bitBE(0x00,streamFile) == 0x00000003 && read_32bitBE(0x04,streamFile) == 0x00000002) { /* PS3 */
+    if (read_32bitBE(0x00,streamFile) == 0x00000003) { /* PS3 */
         read_32bit = read_32bitBE;
         read_16bit = read_16bitBE;
     }
-    else if (read_32bitBE(0x00,streamFile) == 0x03000000 && read_32bitBE(0x04,streamFile) == 0x02000000) { /* Vita/PS4 */
+    else if (read_32bitBE(0x00,streamFile) == 0x03000000) { /* Vita/PS4 */
         read_32bit = read_32bitLE;
         read_16bit = read_16bitLE;
     }
@@ -37,17 +37,22 @@ VGMSTREAM * init_vgmstream_bnk_sony(STREAMFILE *streamFile) {
         goto fail;
     }
 
+    parts = read_32bit(0x04,streamFile);
+    if (parts < 2 || parts > 3) goto fail;
+
     sblk_offset = read_32bit(0x08,streamFile);
     /* 0x0c: sklb size */
     data_offset = read_32bit(0x10,streamFile);
     data_size = read_32bit(0x14,streamFile);
+    /* 0x18: ZLSD small footer, rare [Yakuza 6's Puyo Puyo (PS4)] */
+    /* 0x1c: ZLSD size */
 
     /* SE banks, also used for music. Most table fields seems reserved/defaults and
      * don't change much between subsongs or files, so they aren't described in detail */
 
 
     /* SBlk part: parse header */
-    if (read_32bit(sblk_offset+0x00,streamFile) != 0x6B6C4253) /* "SBlk" (sample block?) */
+    if (read_32bit(sblk_offset+0x00,streamFile) != 0x6B6C4253) /* "klBS" (SBlk = sample block?) */
         goto fail;
     version = read_32bit(sblk_offset+0x04,streamFile);
     /* 0x08: possibly when version=0x0d, 0x03=Vita, 0x06=PS4 */
@@ -83,6 +88,7 @@ VGMSTREAM * init_vgmstream_bnk_sony(STREAMFILE *streamFile) {
                 break;
 
             case 0x0d: /* Polara (Vita), Crypt of the Necrodancer (Vita) */
+            case 0x0e: /* Yakuza 6's Puyo Puyo (PS4) */
                 table1_offset    = sblk_offset + read_32bit(sblk_offset+0x18,streamFile);
                 table2_offset    = sblk_offset + read_32bit(sblk_offset+0x1c,streamFile);
                 table3_offset    = sblk_offset + read_32bit(sblk_offset+0x2c,streamFile);
@@ -159,6 +165,7 @@ VGMSTREAM * init_vgmstream_bnk_sony(STREAMFILE *streamFile) {
           //case 0x04: /* different format? */
             case 0x09:
             case 0x0d:
+            case 0x0e:
                 /* find if this sound has an assigned name in table1 */
                 for (i = 0; i < section_entries; i++) {
                     off_t entry_offset = (uint16_t)read_16bit(table1_offset+(i*table1_entry_size)+table1_suboffset+0x00,streamFile);
@@ -255,6 +262,7 @@ VGMSTREAM * init_vgmstream_bnk_sony(STREAMFILE *streamFile) {
                 break;
 
             case 0x0d:
+            case 0x0e:
                 type = read_16bit(start_offset+0x00,streamFile);
                 if (read_32bit(start_offset+0x04,streamFile) != 0x01) /* type? */
                     goto fail;

--- a/src/meta/ea_eaac.c
+++ b/src/meta/ea_eaac.c
@@ -666,7 +666,7 @@ static VGMSTREAM * init_vgmstream_eaaudiocore_header(STREAMFILE * streamHead, ST
 
 #ifdef VGM_USE_FFMPEG
         case EAAC_CODEC_EAOPUS: { /* EAOpus (unknown FourCC) [FIFA 17 (PC), FIFA 19 (Switch)]*/
-            int skip = 0;//todo
+            int skip = 0;
             size_t data_size;
 
             /* We'll remove EA blocks and pass raw data to FFmpeg Opus decoder */
@@ -674,6 +674,7 @@ static VGMSTREAM * init_vgmstream_eaaudiocore_header(STREAMFILE * streamHead, ST
             temp_streamFile = setup_eaac_streamfile(streamData, eaac.version, eaac.codec, eaac.streamed,0,0, eaac.stream_offset);
             if (!temp_streamFile) goto fail;
 
+            skip = ea_opus_get_encoder_delay(0x00, temp_streamFile);
             data_size = get_streamfile_size(temp_streamFile);
 
             vgmstream->codec_data = init_ffmpeg_ea_opus(temp_streamFile, 0x00,data_size, vgmstream->channels, skip, vgmstream->sample_rate);

--- a/src/meta/ea_eaac.c
+++ b/src/meta/ea_eaac.c
@@ -664,10 +664,27 @@ static VGMSTREAM * init_vgmstream_eaaudiocore_header(STREAMFILE * streamHead, ST
         }
 #endif
 
-        case EAAC_CODEC_EASPEEX: /* EASpeex (libspeex variant, base versions vary: 1.0.5, 1.2beta3) */
-            /* TODO */
-        case EAAC_CODEC_EAOPUS: /* EAOpus (inside each SNS/SPS block is 16b frame size + standard? Opus packet) */
-            /* TODO */
+#ifdef VGM_USE_FFMPEG
+        case EAAC_CODEC_EAOPUS: { /* EAOpus (unknown FourCC) [FIFA 17 (PC), FIFA 19 (Switch)]*/
+            int skip = 0;//todo
+            size_t data_size;
+
+            /* We'll remove EA blocks and pass raw data to FFmpeg Opus decoder */
+
+            temp_streamFile = setup_eaac_streamfile(streamData, eaac.version, eaac.codec, eaac.streamed,0,0, eaac.stream_offset);
+            if (!temp_streamFile) goto fail;
+
+            data_size = get_streamfile_size(temp_streamFile);
+
+            vgmstream->codec_data = init_ffmpeg_ea_opus(temp_streamFile, 0x00,data_size, vgmstream->channels, skip, vgmstream->sample_rate);
+            if (!vgmstream->codec_data) goto fail;
+            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->layout_type = layout_none;
+            break;
+        }
+#endif
+
+        case EAAC_CODEC_EASPEEX: /* EASpeex (libspeex variant, base versions vary: 1.0.5, 1.2beta3) */ //todo
         default:
             VGM_LOG("EA EAAC: unknown codec 0x%02x\n", eaac.codec);
             goto fail;

--- a/src/meta/nxa.c
+++ b/src/meta/nxa.c
@@ -40,7 +40,7 @@ VGMSTREAM * init_vgmstream_opus_nxa(STREAMFILE *streamFile) {
         vgmstream->layout_type = layout_none;
 
         if (vgmstream->num_samples == 0) {
-            vgmstream->num_samples = switch_opus_get_samples(start_offset, data_size, vgmstream->sample_rate, streamFile) - skip;
+            vgmstream->num_samples = switch_opus_get_samples(start_offset, data_size, streamFile) - skip;
         }
     }
 #else

--- a/src/meta/opus.c
+++ b/src/meta/opus.c
@@ -50,7 +50,7 @@ static VGMSTREAM * init_vgmstream_opus(STREAMFILE *streamFile, meta_t meta_type,
         vgmstream->layout_type = layout_none;
 
         if (vgmstream->num_samples == 0) {
-            vgmstream->num_samples = switch_opus_get_samples(start_offset, data_size, vgmstream->sample_rate, streamFile) - skip;
+            vgmstream->num_samples = switch_opus_get_samples(start_offset, data_size, streamFile) - skip;
         }
     }
 #else

--- a/src/meta/ue4opus.c
+++ b/src/meta/ue4opus.c
@@ -26,13 +26,11 @@ VGMSTREAM * init_vgmstream_ue4opus(STREAMFILE *streamFile) {
     /* 0x0f(2): frame count */
     loop_flag = 0;
 
-    /* UE4Opus encodes 60ms (music) or 120ms (voice) frames, and encoder delay seems 1/8
-     * of samples per frame (may be more complex but wave looks ok-ish) */
-    //todo does UE4 actually care about encoder delay?
-    skip = (60 * 48000 / 1000) / 8; /* 48000 is the internal/resampled rate */
-
     start_offset = 0x11;
     data_size = get_streamfile_size(streamFile) - start_offset;
+
+    /* usually uses 60ms for music (delay of 360 samples) */
+    skip = ue4_opus_get_encoder_delay(start_offset, streamFile);
 
 
     /* build the VGMSTREAM */
@@ -49,10 +47,6 @@ VGMSTREAM * init_vgmstream_ue4opus(STREAMFILE *streamFile) {
         if (!vgmstream->codec_data) goto fail;
         vgmstream->coding_type = coding_FFmpeg;
         vgmstream->layout_type = layout_none;
-
-        if (vgmstream->num_samples == 0) {
-            vgmstream->num_samples = ue4_opus_get_samples(start_offset, data_size, vgmstream->sample_rate, streamFile) - skip;
-        }
     }
 #else
     goto fail;

--- a/src/meta/wwise.c
+++ b/src/meta/wwise.c
@@ -502,7 +502,7 @@ VGMSTREAM * init_vgmstream_wwise(STREAMFILE *streamFile) {
         }
 
         case OPUS: {    /* Switch */
-            size_t skip = 0; /* Wwise doesn't seem to use it? (0x138 /0x3E8 ~default) */
+            size_t skip;
 
             /* values up to 0x14 seem fixed and similar to HEVAG's (block_align 0x02/04, bits_per_sample 0x10) */
             if (ww.fmt_size == 0x28) {
@@ -518,6 +518,8 @@ VGMSTREAM * init_vgmstream_wwise(STREAMFILE *streamFile) {
             else {
                 goto fail;
             }
+
+            skip = switch_opus_get_encoder_delay(start_offset, streamFile); /* should be 120 */
 
             vgmstream->codec_data = init_ffmpeg_switch_opus(streamFile, start_offset,ww.data_size, vgmstream->channels, skip, vgmstream->sample_rate);
             if (!vgmstream->codec_data) goto fail;

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -1032,7 +1032,6 @@ typedef struct {
 typedef struct {
    sample buffer[960];
    void *handle;
-   int16_t *code_buffer;
 } g719_codec_data;
 #endif
 

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -706,6 +706,7 @@ typedef enum {
     meta_NXA,
     meta_ADPCM_CAPCOM,
     meta_UE4OPUS,
+    meta_OGG_LSE,
 
 } meta_t;
 


### PR DESCRIPTION
- Add .lse Ogg [Labyrinth of Refrain (PC)]
- Add EAOpus [FIFA 17 (PC), FIFA 19 (Switch)]
- Fix .wem Opus encoder delay/gapless [Mario Rabbids (Switch)]
- Restore G719 max frame size as 2560 bits (0x140) is decoder max
- Add Sony .BNK v14 [Yakuza 6's Puyo Puyo (PS4)]

