### PR TITLE
xpcm nwav xvag

### DIFF
--- a/ext_libs/clHCA.c
+++ b/ext_libs/clHCA.c
@@ -1088,9 +1088,13 @@ int clHCA_DecodeBlock(clHCA *hca, void *data, unsigned int size) {
         }
     }
 
-    /* should read all frame sans checksum at most */
-    if (br.bit > br.size - 16)
+    /* should read all frame sans checksum (16b) at most */
+    /* one frame was found to read up to 14b left (cross referenced with CRI's tools),
+     * perhaps some encoding hiccup [World of Final Fantasy Maxima (Switch) am_ev21_0170 video],
+     * though this validation makes more sense when testing keys and isn't normally done on decode */
+    if (br.bit + 14 > br.size) { /* relax validation a bit for that case */
         return HCA_ERROR_BITREADER;
+    }
 
     return 0;
 }
@@ -1159,7 +1163,7 @@ static int decode1_unpack_channel(stChannel *ch, clData *br,
                 if (delta != expected_delta) {
                     /* may happen with bad keycodes, scalefactors must be 6b indexes */
                     int scalefactor_test = (int)scalefactor_prev + ((int)delta - (int)extra_delta);
-                    if (scalefactor_test < 0 || scalefactor_test > 64) {
+                    if (scalefactor_test < 0 || scalefactor_test >= 64) {
                         return HCA_ERROR_UNPACK;
                     }
 

--- a/src/coding/circus_decoder.c
+++ b/src/coding/circus_decoder.c
@@ -1,0 +1,29 @@
+#include "coding.h"
+
+
+/* Circus XPCM mode 2 decoding, verified vs EF.exe (info from foo_adpcm/libpcm and https://github.com/lioncash/ExtractData) */
+void decode_circus_adpcm(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do) {
+    int i, sample_pos = 0;
+    int32_t hist = stream->adpcm_history1_32;
+    int scale = stream->adpcm_scale;
+    off_t frame_offset = stream->offset; /* frame size is 1 */
+
+
+    for (i = first_sample; i < first_sample + samples_to_do; i++) {
+        int8_t code = read_8bit(frame_offset+i,stream->streamfile);
+
+        hist += code << scale;
+        if (code == 0) {
+            if (scale > 0)
+                scale--;
+        }
+        else if (code == 127 || code == -128) {
+            if (scale < 8)
+                scale++;
+        }
+        outbuf[sample_pos] = hist;
+    }
+
+    stream->adpcm_history1_32 = hist;
+    stream->adpcm_scale = scale;
+}

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -165,6 +165,8 @@ void decode_xmd(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, 
 /* derf_decoder */
 void decode_derf(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do);
 
+/* circus_decoder */
+void decode_circus_adpcm(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do);
 
 /* ea_mt_decoder*/
 ea_mt_codec_data *init_ea_mt(int channels, int type);

--- a/src/formats.c
+++ b/src/formats.c
@@ -1109,6 +1109,7 @@ static const meta_info meta_info_list[] = {
         {meta_XOPUS,                "Exient XOPUS header"},
         {meta_VS_FFX,               "Square VS header"},
         {meta_NWAV,                 "Chunsoft NWAV header"},
+        {meta_XPCM,                 "Circus XPCM header"},
 
 };
 

--- a/src/formats.c
+++ b/src/formats.c
@@ -262,6 +262,7 @@ static const char* extension_list[] = {
     "npsf", //fake extension/header id for .nps (in bigfiles)
     "nus3bank",
     "nwa",
+    "nwav",
     "nxa",
 
     //"ogg", //common
@@ -1107,6 +1108,7 @@ static const meta_info meta_info_list[] = {
         {meta_VA3,                  "Konami VA3 header" },
         {meta_XOPUS,                "Exient XOPUS header"},
         {meta_VS_FFX,               "Square VS header"},
+        {meta_NWAV,                 "Chunsoft NWAV header"},
 
 };
 

--- a/src/formats.c
+++ b/src/formats.c
@@ -605,6 +605,7 @@ static const coding_info coding_info_list[] = {
         {coding_DERF,               "Xilam DERF 8-bit DPCM"},
         {coding_ACM,                "InterPlay ACM"},
         {coding_NWA,                "VisualArt's NWA DPCM"},
+        {coding_CIRCUS_ADPCM,       "Circus 8-bit ADPCM"},
 
         {coding_EA_MT,              "Electronic Arts MicroTalk"},
 

--- a/src/libvgmstream.vcproj
+++ b/src/libvgmstream.vcproj
@@ -1618,6 +1618,10 @@
                     RelativePath=".\meta\xopus.c"
                     >
                 </File>
+                <File
+                    RelativePath=".\meta\xpcm.c"
+                    >
+                </File>
 				<File
 					RelativePath=".\meta\xss.c"
 					>

--- a/src/libvgmstream.vcproj
+++ b/src/libvgmstream.vcproj
@@ -851,6 +851,10 @@
                     >
                 </File>
                 <File
+                    RelativePath=".\meta\nwav.c"
+                    >
+                </File>
+                <File
                     RelativePath=".\meta\nxa.c"
                     >
                 </File>

--- a/src/libvgmstream.vcproj
+++ b/src/libvgmstream.vcproj
@@ -1727,6 +1727,14 @@
 					>
 				</File>
                 <File
+                    RelativePath=".\coding\celt_fsb_decoder.c"
+                    >
+                </File>
+                <File
+                    RelativePath=".\coding\circus_decoder.c"
+                    >
+                </File>
+                <File
                     RelativePath=".\coding\coding_utils.c"
                     >
                 </File>

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -319,6 +319,7 @@
     <ClCompile Include="meta\nub_xma.c" />
     <ClCompile Include="meta\nus3bank.c" />
     <ClCompile Include="meta\nwa.c" />
+    <ClCompile Include="meta\nwav.c" />
     <ClCompile Include="meta\nxa.c" />
     <ClCompile Include="meta\nxap.c" />
     <ClCompile Include="meta\ogg_vorbis.c" />

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -478,6 +478,7 @@
     <ClCompile Include="meta\xma.c" />
     <ClCompile Include="meta\xnb.c" />
     <ClCompile Include="meta\xopus.c" />
+    <ClCompile Include="meta\xpcm.c" />
     <ClCompile Include="meta\xss.c" />
     <ClCompile Include="meta\xvag.c" />
     <ClCompile Include="meta\xmd.c" />

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -126,6 +126,7 @@
     <ClCompile Include="coding\at3plus_decoder.c" />
     <ClCompile Include="coding\atrac9_decoder.c" />
     <ClCompile Include="coding\celt_fsb_decoder.c" />
+    <ClCompile Include="coding\circus_decoder.c" />
     <ClCompile Include="coding\coding_utils.c" />
     <ClCompile Include="coding\ffmpeg_decoder.c" />
     <ClCompile Include="coding\ffmpeg_decoder_custom_opus.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -523,6 +523,9 @@
     <ClCompile Include="meta\nwa.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\nwav.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\nxa.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1456,6 +1456,9 @@
     <ClCompile Include="meta\xopus.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\xpcm.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\x360_cxs.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1417,6 +1417,9 @@
     <ClCompile Include="coding\celt_fsb_decoder.c">
       <Filter>coding\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="coding\circus_decoder.c">
+      <Filter>coding\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="meta\bcstm.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>

--- a/src/meta/bnk_sony.c
+++ b/src/meta/bnk_sony.c
@@ -1,7 +1,7 @@
 #include "meta.h"
 #include "../coding/coding.h"
 
-typedef enum { PSX, PCM16, ATRAC9 } bnk_codec;
+typedef enum { PSX, PCM16, ATRAC9, HEVAG } bnk_codec;
 
 /* BNK - Sony's Scream Tool bank format [Puyo Puyo Tetris (PS4), NekoBuro: Cats Block (Vita)] */
 VGMSTREAM * init_vgmstream_bnk_sony(STREAMFILE *streamFile) {
@@ -313,7 +313,7 @@ VGMSTREAM * init_vgmstream_bnk_sony(STREAMFILE *streamFile) {
                         loop_length = read_32bit(start_offset+0x1c,streamFile);
                         loop_end = loop_start + loop_length; /* loop_start is -1 if not set */
 
-                        codec = PSX;
+                        codec = HEVAG;
                         break;
 
                     default:
@@ -378,6 +378,17 @@ VGMSTREAM * init_vgmstream_bnk_sony(STREAMFILE *streamFile) {
         case PSX:
             vgmstream->sample_rate = 48000;
             vgmstream->coding_type = coding_PSX;
+            vgmstream->layout_type = layout_interleave;
+            vgmstream->interleave_block_size = interleave;
+
+            vgmstream->num_samples = ps_bytes_to_samples(stream_size,channel_count);
+            vgmstream->loop_start_sample = loop_start;
+            vgmstream->loop_end_sample = loop_end;
+            break;
+
+        case HEVAG:
+            vgmstream->sample_rate = 48000;
+            vgmstream->coding_type = coding_HEVAG;
             vgmstream->layout_type = layout_interleave;
             vgmstream->interleave_block_size = interleave;
 

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -806,4 +806,6 @@ VGMSTREAM * init_vgmstream_msf_banpresto_2msf(STREAMFILE * streamFile);
 
 VGMSTREAM * init_vgmstream_nwav(STREAMFILE * streamFile);
 
+VGMSTREAM * init_vgmstream_xpcm(STREAMFILE * streamFile);
+
 #endif /*_META_H*/

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -804,4 +804,6 @@ VGMSTREAM * init_vgmstream_vs_ffx(STREAMFILE * streamFile);
 VGMSTREAM * init_vgmstream_msf_banpresto_wmsf(STREAMFILE * streamFile);
 VGMSTREAM * init_vgmstream_msf_banpresto_2msf(STREAMFILE * streamFile);
 
+VGMSTREAM * init_vgmstream_nwav(STREAMFILE * streamFile);
+
 #endif /*_META_H*/

--- a/src/meta/nwav.c
+++ b/src/meta/nwav.c
@@ -1,0 +1,57 @@
+#include "meta.h"
+#include "../coding/coding.h"
+
+/* NWAV - from Chunsoft games [Fuurai no Shiren Gaiden: Onnakenshi Asuka Kenzan! (PC)] */
+VGMSTREAM * init_vgmstream_nwav(STREAMFILE *streamFile) {
+    VGMSTREAM * vgmstream = NULL;
+    off_t start_offset;
+
+
+    /* checks */
+    /* .nwav: header id (no filenames in bigfiles) */
+    if ( !check_extensions(streamFile,"nwav") )
+        goto fail;
+    if (read_32bitBE(0x00,streamFile) != 0x4E574156) /* "NWAV" */
+        goto fail;
+
+
+#ifdef VGM_USE_VORBIS
+    {
+        ogg_vorbis_meta_info_t ovmi = {0};
+        int channels;
+
+        /* 0x04: version? */
+        /* 0x08: crc? */
+        ovmi.stream_size = read_32bitLE(0x0c, streamFile);
+        ovmi.loop_end = read_32bitLE(0x10, streamFile); /* num_samples, actually */
+        /* 0x14: sample rate */
+        /* 0x18: bps? (16) */
+        channels = read_8bit(0x19, streamFile);
+        start_offset = read_16bitLE(0x1a, streamFile);
+
+        ovmi.loop_flag = read_16bitLE(0x1c, streamFile) != 0; /* loop count? -1 = loops */
+        /* 0x1e: always 2? */
+        /* 0x20: always 1? */
+        ovmi.loop_start = read_32bitLE(0x24, streamFile);
+        /* 0x28: always 1? */
+        /* 0x2a: always 1? */
+        /* 0x2c: always null? */
+
+        ovmi.meta_type = meta_NWAV;
+
+        /* values are in resulting bytes */
+        ovmi.loop_start = ovmi.loop_start / sizeof(int16_t) / channels;
+        ovmi.loop_end = ovmi.loop_end / sizeof(int16_t) / channels;
+
+        vgmstream = init_vgmstream_ogg_vorbis_callbacks(streamFile, NULL, start_offset, &ovmi);
+    }
+#else
+    goto fail;
+#endif
+
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/meta/sgxd.c
+++ b/src/meta/sgxd.c
@@ -111,11 +111,6 @@ VGMSTREAM * init_vgmstream_sgxd(STREAMFILE *streamFile) {
     if (name_offset)
         read_string(vgmstream->stream_name,STREAM_NAME_SIZE, name_offset,streamHeader);
 
-    /* needs -1 to match RIFF AT3's loop chunk
-     * (maybe SGXD = "loop before this sample" rather than "loop after this sample" as expected by vgmstream) */
-    if (vgmstream->loop_end_sample > 0)
-        vgmstream->loop_end_sample -= 1;
-
     switch (type) {
         case 0x03:      /* PS-ADPCM [Genji (PS3), Ape Escape Move (PS3)]*/
             vgmstream->coding_type = coding_PSX;

--- a/src/meta/xpcm.c
+++ b/src/meta/xpcm.c
@@ -9,7 +9,6 @@ VGMSTREAM * init_vgmstream_xpcm(STREAMFILE *streamFile) {
     int loop_flag, channel_count, codec, subcodec, sample_rate;
 
 
-
     /* checks */
     if (!check_extensions(streamFile, "pcm"))
         goto fail;
@@ -27,7 +26,7 @@ VGMSTREAM * init_vgmstream_xpcm(STREAMFILE *streamFile) {
     /* 0x14: average bitrate */
     /* 0x18: block size */
     /* 0x1a: output bits (16) */
-    start_offset = 0x1c;
+    start_offset = 0x1c; /* compressed size in codec 0x01/03 */
 
     loop_flag  = 0;
 
@@ -47,11 +46,16 @@ VGMSTREAM * init_vgmstream_xpcm(STREAMFILE *streamFile) {
             vgmstream->layout_type = layout_interleave;
             vgmstream->interleave_block_size = 0x02;
             break;
+        case 0x02:
+            if (subcodec != 0) goto fail;
+            vgmstream->coding_type = coding_CIRCUS_ADPCM;
+            vgmstream->layout_type = layout_interleave;
+            vgmstream->interleave_block_size = 0x01;
+            break;
+
         case 0x01: /* LZSS + VQ */
-        case 0x02: /* ADPCM */
         case 0x03: /* unknown */
         default:
-            /* 0x1c contains compressed size for those */
             goto fail;
     }
 

--- a/src/meta/xpcm.c
+++ b/src/meta/xpcm.c
@@ -1,0 +1,65 @@
+#include "meta.h"
+#include "../coding/coding.h"
+
+/* XPCM - from Circus games [Eternal Fantasy (PC), D.C. White Season (PC)] */
+VGMSTREAM * init_vgmstream_xpcm(STREAMFILE *streamFile) {
+    VGMSTREAM * vgmstream = NULL;
+    off_t start_offset;
+    size_t decompressed_size;
+    int loop_flag, channel_count, codec, subcodec, sample_rate;
+
+
+
+    /* checks */
+    if (!check_extensions(streamFile, "pcm"))
+        goto fail;
+
+    if (read_32bitBE(0x00,streamFile) != 0x5850434D) /* "XPCM" "*/
+        goto fail;
+
+    decompressed_size = read_32bitLE(0x04,streamFile); /* (data_size for PCM) */
+    codec    = read_8bit(0x08, streamFile);
+    subcodec = read_8bit(0x09, streamFile);
+    /* 0x0a: always null */
+    /* 0x0c: always 0x01 (PCM codec) */
+    channel_count = read_16bitLE(0x0e,streamFile);
+    sample_rate = read_32bitLE(0x10,streamFile);
+    /* 0x14: average bitrate */
+    /* 0x18: block size */
+    /* 0x1a: output bits (16) */
+    start_offset = 0x1c;
+
+    loop_flag  = 0;
+
+
+    /* build the VGMSTREAM */
+    vgmstream = allocate_vgmstream(channel_count, loop_flag);
+    if (!vgmstream) goto fail;
+
+    vgmstream->meta_type = meta_XPCM;
+    vgmstream->sample_rate = sample_rate;
+    vgmstream->num_samples = decompressed_size / sizeof(int16_t) / channel_count;
+
+    switch(codec) {
+        case 0x00:
+            if (subcodec != 0) goto fail;
+            vgmstream->coding_type = coding_PCM16LE;
+            vgmstream->layout_type = layout_interleave;
+            vgmstream->interleave_block_size = 0x02;
+            break;
+        case 0x01: /* LZSS + VQ */
+        case 0x02: /* ADPCM */
+        case 0x03: /* unknown */
+        default:
+            /* 0x1c contains compressed size for those */
+            goto fail;
+    }
+
+    if (!vgmstream_open_stream(vgmstream,streamFile,start_offset))
+        goto fail;
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/meta/xvag.c
+++ b/src/meta/xvag.c
@@ -106,6 +106,15 @@ VGMSTREAM * init_vgmstream_xvag(STREAMFILE *streamFile) {
         xvag.loop_end = ps_bytes_to_samples(file_size - start_offset, xvag.channels);
     }
 
+    /* May use 'MP3 Surround' for multichannel [Twisted Metal (PS3), The Last of Us (PS4) test file]
+     * It's a mutant MP3 that decodes as 2ch but output can be routed to 6ch somehow, if manually
+     * activated. Fraunhofer IIS's MP3sPlayer can do it, as can PS3 (fw v2.40+) but no others seems to.
+     * So simply play as 2ch, they sound ok with slightly wider feel. No XVAG/MP3 flag exists to detect,
+     * can be found in v0x60 (without layers/subsongs) and v0x61 (with them set as 1) */
+    if (xvag.codec == 0x08 && xvag.channels == 6 && xvag.layers == 1) {
+        xvag.channels = 2;
+    }
+
 
     /* build the VGMSTREAM */
     vgmstream = allocate_vgmstream(xvag.channels,xvag.loop_flag);

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -448,6 +448,7 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_msf_banpresto_wmsf,
     init_vgmstream_msf_banpresto_2msf,
     init_vgmstream_nwav,
+    init_vgmstream_xpcm,
 
     /* lowest priority metas (should go after all metas, and TXTH should go before raw formats) */
     init_vgmstream_txth,            /* proper parsers should supersede TXTH, once added */

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -1124,6 +1124,7 @@ int get_vgmstream_samples_per_frame(VGMSTREAM * vgmstream) {
         case coding_DERF:
         case coding_NWA:
         case coding_SASSC:
+        case coding_CIRCUS_ADPCM:
             return 1;
 
         case coding_IMA:
@@ -1299,6 +1300,7 @@ int get_vgmstream_frame_size(VGMSTREAM * vgmstream) {
         case coding_DERF:
         case coding_NWA:
         case coding_SASSC:
+        case coding_CIRCUS_ADPCM:
             return 0x01;
 
         case coding_IMA:
@@ -1740,6 +1742,12 @@ void decode_vgmstream(VGMSTREAM * vgmstream, int samples_written, int samples_to
         case coding_DERF:
             for (ch = 0; ch < vgmstream->channels; ch++) {
                 decode_derf(&vgmstream->ch[ch],buffer+samples_written*vgmstream->channels+ch,
+                        vgmstream->channels,vgmstream->samples_into_block,samples_to_do);
+            }
+            break;
+        case coding_CIRCUS_ADPCM:
+            for (ch = 0; ch < vgmstream->channels; ch++) {
+                decode_circus_adpcm(&vgmstream->ch[ch],buffer+samples_written*vgmstream->channels+ch,
                         vgmstream->channels,vgmstream->samples_into_block,samples_to_do);
             }
             break;

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -447,6 +447,7 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_vs_ffx,
     init_vgmstream_msf_banpresto_wmsf,
     init_vgmstream_msf_banpresto_2msf,
+    init_vgmstream_nwav,
 
     /* lowest priority metas (should go after all metas, and TXTH should go before raw formats) */
     init_vgmstream_txth,            /* proper parsers should supersede TXTH, once added */

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -703,6 +703,7 @@ typedef enum {
     meta_XOPUS,
     meta_VS_FFX,
     meta_NWAV,
+    meta_XPCM,
 
 } meta_t;
 

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -702,6 +702,7 @@ typedef enum {
     meta_VA3,               /* DDR Supernova 2 AC */
     meta_XOPUS,
     meta_VS_FFX,
+    meta_NWAV,
 
 } meta_t;
 

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -159,6 +159,7 @@ typedef enum {
     coding_DERF,            /* DERF 8-bit DPCM */
     coding_ACM,             /* InterPlay ACM */
     coding_NWA,             /* VisualArt's NWA */
+    coding_CIRCUS_ADPCM,    /* Circus 8-bit ADPCM */
 
     coding_EA_MT,           /* Electronic Arts MicroTalk (linear-predictive speech codec) */
 

--- a/winamp/in_vgmstream.c
+++ b/winamp/in_vgmstream.c
@@ -1450,6 +1450,7 @@ winamp_tags last_tags;
  * Winamp requests one tag at a time and may reask for the same tag several times */
 static void load_tagfile_info(in_char* filename) {
     STREAMFILE *tagFile = NULL;
+    in_char filename_clean[PATH_LIMIT];
     char filename_utf8[PATH_LIMIT];
     char tagfile_path_utf8[PATH_LIMIT];
     in_char tagfile_path_i[PATH_LIMIT];
@@ -1461,13 +1462,15 @@ static void load_tagfile_info(in_char* filename) {
         return;
     }
 
+    /* clean extra part for subsong tags */
+    parse_fn_string(filename, NULL, filename_clean,PATH_LIMIT);
 
-    if (wa_strcmp(last_tags.filename, filename) == 0) {
+    if (wa_strcmp(last_tags.filename, filename_clean) == 0) {
         return; /* not changed, tags still apply */
     }
 
     /* tags are now for this filename, find tagfile path */
-    wa_ichar_to_char(filename_utf8, PATH_LIMIT, filename);
+    wa_ichar_to_char(filename_utf8, PATH_LIMIT, filename_clean);
     strcpy(tagfile_path_utf8,filename_utf8);
 
     path = strrchr(tagfile_path_utf8,'\\');
@@ -1480,7 +1483,7 @@ static void load_tagfile_info(in_char* filename) {
     }
     wa_char_to_ichar(tagfile_path_i, PATH_LIMIT, tagfile_path_utf8);
 
-    wa_strcpy(last_tags.filename, filename);
+    wa_strcpy(last_tags.filename, filename_clean);
     last_tags.tag_count = 0;
 
     /* load all tags from tagfile */


### PR DESCRIPTION
- Fix truncated XMA .wem [The Bureau - XCOM Declassified (X360)]
- Play as stereo MP3 Surround .xvag [Twisted Metal (PS3)]
- Add NWAV [Fuurai no Shiren Gaiden: Onnakenshi Asuka Kenzan! (PC)]
- Add PCM16LE/ADPCM .xpcm [Eternal Fantasy (PC)]
- Fix HEVAG Sony .bnk [Yuusha Shisu (Vita)]
- Improve external .sxd handling
- Fix SGXD loop end being off by 1 sample
- Fix subsong tags in winamp
- Relax HCA validation for rare bad frames
