### PR TITLE
xma msf akb

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ ordering), the file itself just 'looks' like an M3U.
 Format is:
 ```
 # ignored comment
+# $GLOBAL_COMMAND value (extra features)
 # @GLOBAL_TAG value (applies all following tracks)
 
 # %LOCAL_TAG value (applies to next track only)
@@ -257,6 +258,10 @@ separated by one or multiple spaces. Repeated tags overwrite previous
 _filename_ though, so any @TAG below would be ignored.
 
 Playlist formatting should follow player's config. ASCII or UTF-8 tags work.
+
+GLOBAL_COMMANDs currently can be: 
+- AUTOTRACK: sets %TRACK% tag automatically (1..N as files are encountered
+  in the tag file).
 
 
 ## Supported codec types
@@ -291,6 +296,7 @@ are used in few games.
 - FMOD FADPCM 4-bit ADPCM
 - Konami XMD 4-bit ADPCM
 - Argonaut ASF 4-bit ADPCM
+- Circus XPCM ADPCM
 - SDX2 2:1 Squareroot-Delta-Exact compression DPCM
 - CBD2 2:1 Cuberoot-Delta-Exact compression DPCM
 - Activision EXAKT SASSC DPCM

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -323,7 +323,6 @@ typedef struct {
 
     /* output */
     int32_t num_samples;
-    int32_t skip_samples;
     int32_t loop_start_sample;
     int32_t loop_end_sample;
 } ms_sample_data;
@@ -334,6 +333,9 @@ void wma_get_samples(ms_sample_data * msd, STREAMFILE *streamFile, int block_ali
 void xma1_parse_fmt_chunk(STREAMFILE *streamFile, off_t chunk_offset, int * channels, int * sample_rate, int * loop_flag, int32_t * loop_start_b, int32_t * loop_end_b, int32_t * loop_subframe, int be);
 void xma2_parse_fmt_chunk_extra(STREAMFILE *streamFile, off_t chunk_offset, int * loop_flag, int32_t * out_num_samples, int32_t * out_loop_start_sample, int32_t * out_loop_end_sample, int be);
 void xma2_parse_xma2_chunk(STREAMFILE *streamFile, off_t chunk_offset, int * channels, int * sample_rate, int * loop_flag, int32_t * num_samples, int32_t * loop_start_sample, int32_t * loop_end_sample);
+
+void xma_fix_raw_samples(VGMSTREAM *vgmstream, STREAMFILE*streamFile, off_t stream_offset, size_t stream_size, off_t chunk_offset, int fix_num_samples, int fix_loop_samples);
+
 int riff_get_fact_skip_samples(STREAMFILE * streamFile, off_t start_offset);
 
 size_t atrac3_bytes_to_samples(size_t bytes, int full_block_align);

--- a/src/formats.c
+++ b/src/formats.c
@@ -1111,6 +1111,7 @@ static const meta_info meta_info_list[] = {
         {meta_VS_FFX,               "Square VS header"},
         {meta_NWAV,                 "Chunsoft NWAV header"},
         {meta_XPCM,                 "Circus XPCM header"},
+        {meta_MSF_TAMASOFT,         "TamaSoft MSF header"},
 
 };
 

--- a/src/libvgmstream.vcproj
+++ b/src/libvgmstream.vcproj
@@ -1090,6 +1090,10 @@
                     RelativePath=".\meta\msf_banpresto.c"
                     >
                 </File>
+                <File
+                    RelativePath=".\meta\msf_tamasoft.c"
+                    >
+                </File>
 				<File
 					RelativePath=".\meta\mss.c"
 					>

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -157,6 +157,7 @@
     <ClCompile Include="meta\mp4.c" />
     <ClCompile Include="meta\msb_msh.c" />
     <ClCompile Include="meta\msf_banpresto.c" />
+    <ClCompile Include="meta\msf_tamasoft.c" />
     <ClCompile Include="meta\ngca.c" />
     <ClCompile Include="meta\opus.c" />
     <ClCompile Include="meta\nub_vag.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1402,6 +1402,9 @@
     <ClCompile Include="meta\msf_banpresto.c">
       <Filter>meta\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="meta\msf_tamasoft.c">
+      <Filter>meta\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="coding\mp4_aac_decoder.c">
       <Filter>coding\Source Files</Filter>
     </ClCompile>

--- a/src/meta/adx_keys.h
+++ b/src/meta/adx_keys.h
@@ -195,10 +195,10 @@ static const adxkey_info adxkey9_list[] = {
         /* Phantasy Star Online 2 */
         {0x07d2,0x1ec5,0x0c7f, NULL,0},                     // guessed with degod
 
-        /* Dragon Ball Z: Dokkan Battle */
+        /* Dragon Ball Z: Dokkan Battle (Android/iOS) */
         {0x0003,0x0d19,0x043b, NULL,416383518},             // 0000000018D1821E
 
-        /* Kisou Ryouhei Gunhound EX (2013-01-31)(Dracue)[PSP] */
+        /* Kisou Ryouhei Gunhound EX (PSP) */
         {0x0005,0x0bcd,0x1add, NULL,683461999},             // 0000000028BCCD6F
 
         /* Raramagi (Android) */
@@ -213,12 +213,16 @@ static const adxkey_info adxkey9_list[] = {
         /* Yuuki Yuuna wa Yuusha de aru - Hanayui no Kirameki / Yuyuyui (iOS/Android) */
         {0x3f10,0x3651,0x6d31, NULL,4867249871962584729},   // 438BF1F883653699
 
-        // Super Robot Wars X-Omega (voices) [iOS/Android]
+        /* Super Robot Wars X-Omega (iOS/Android) voices */
         {0x5152,0x7979,0x152b, NULL,165521992944278},       // 0000968A97978A96
 
-        // AKA to BLUE (Android)
+        /* AKA to BLUE (Android) */
         {0x03fc,0x0749,0x12EF, NULL,0},                     // guessed with VGAudio (possible key: 1FE0748978 / 136909719928)
       //{0x0c03,0x0749,0x1459, NULL,0},                     // 2nd guess (possible key: 6018748A2D / 412727151149)
+
+        /* Mashiro Witch (Android) */
+        {0x2669,0x1495,0x2407, NULL,0x55D11D3349495204},    // 55D11D3349495204
+
 };
 
 static const int adxkey8_list_count = sizeof(adxkey8_list) / sizeof(adxkey8_list[0]);

--- a/src/meta/awc.c
+++ b/src/meta/awc.c
@@ -110,6 +110,8 @@ VGMSTREAM * init_vgmstream_awc(STREAMFILE *streamFile) {
                     bytes = ffmpeg_make_riff_xma2(buf, 0x100, awc.num_samples, substream_size, layer_channels, awc.sample_rate, block_count, block_size);
                     data->layers[i]->codec_data = init_ffmpeg_header_offset(temp_streamFile, buf,bytes, substream_offset,substream_size);
 
+                    xma_fix_raw_samples(data->layers[i], temp_streamFile, substream_offset,substream_size, 0, 0,0); /* samples are ok? */
+
                     close_streamfile(temp_streamFile);
                     if (!data->layers[i]->codec_data) goto fail;
                 }
@@ -128,6 +130,8 @@ VGMSTREAM * init_vgmstream_awc(STREAMFILE *streamFile) {
                 if (!vgmstream->codec_data) goto fail;
                 vgmstream->coding_type = coding_FFmpeg;
                 vgmstream->layout_type = layout_none;
+
+                xma_fix_raw_samples(vgmstream, streamFile, awc.stream_offset,awc.stream_size, 0, 0,0); /* samples are ok? */
             }
 
             break;

--- a/src/meta/ea_eaac.c
+++ b/src/meta/ea_eaac.c
@@ -849,6 +849,8 @@ static layered_layout_data* build_layered_eaaudiocore_eaxma(STREAMFILE *streamDa
 
             data->layers[i]->coding_type = coding_FFmpeg;
             data->layers[i]->layout_type = layout_none;
+
+            xma_fix_raw_samples(data->layers[i], temp_streamFile, 0x00,stream_size, 0, 0,0); /* samples are ok? */
         }
 #else
         goto fail;

--- a/src/meta/fsb.c
+++ b/src/meta/fsb.c
@@ -363,6 +363,8 @@ VGMSTREAM * init_vgmstream_fsb(STREAMFILE *streamFile) {
             if (!vgmstream->codec_data) goto fail;
             vgmstream->coding_type = coding_FFmpeg;
             vgmstream->layout_type = layout_none;
+
+            xma_fix_raw_samples(vgmstream, streamFile, fsb.stream_offset,fsb.stream_size, 0, 0,0); /* samples look ok */
             break;
         }
 #endif

--- a/src/meta/fsb5.c
+++ b/src/meta/fsb5.c
@@ -314,7 +314,7 @@ VGMSTREAM * init_vgmstream_fsb5(STREAMFILE *streamFile) {
             break;
 
 #ifdef VGM_USE_FFMPEG
-        case 0x0A: {/* FMOD_SOUND_FORMAT_XMA  [Dark Souls 2 (X360)] */
+        case 0x0A: {/* FMOD_SOUND_FORMAT_XMA  [Minecraft Story Mode (X360)] */
             uint8_t buf[0x100];
             int bytes, block_size, block_count;
 
@@ -323,9 +323,11 @@ VGMSTREAM * init_vgmstream_fsb5(STREAMFILE *streamFile) {
 
             bytes = ffmpeg_make_riff_xma2(buf, 0x100, vgmstream->num_samples, fsb5.stream_size, vgmstream->channels, vgmstream->sample_rate, block_count, block_size);
             vgmstream->codec_data = init_ffmpeg_header_offset(streamFile, buf,bytes, fsb5.stream_offset,fsb5.stream_size);
-            if ( !vgmstream->codec_data ) goto fail;
+            if (!vgmstream->codec_data) goto fail;
             vgmstream->coding_type = coding_FFmpeg;
             vgmstream->layout_type = layout_none;
+
+            xma_fix_raw_samples(vgmstream, streamFile, fsb5.stream_offset,fsb5.stream_size, 0, 0,0); /* samples look ok */
             break;
         }
 #endif

--- a/src/meta/fsb5.c
+++ b/src/meta/fsb5.c
@@ -150,6 +150,12 @@ VGMSTREAM * init_vgmstream_fsb5(STREAMFILE *streamFile) {
 
                         /* when start is 0 seems the song repeats with no real looping (ex. Sonic Boom Fire & Ice jingles) */
                         fsb5.loop_flag = (fsb5.loop_start != 0x00);
+
+                        /* ignore wrong loops in some files [Pac-Man CE2 Plus (Switch) pce2p_bgm_ajurika_*.fsb] */
+                        if (fsb5.loop_start == 0x3c && fsb5.loop_end == 0x007F007F &&
+                                fsb5.num_samples > fsb5.loop_end + 100000) { /* arbitrary limit */
+                            fsb5.loop_flag = 0;
+                        }
                         break;
                     case 0x04:  /* free comment, or maybe SFX info */
                         break;

--- a/src/meta/genh.c
+++ b/src/meta/genh.c
@@ -304,7 +304,6 @@ VGMSTREAM * init_vgmstream_genh(STREAMFILE *streamFile) {
                 else {
                     goto fail;
                 }
-                if (bytes <= 0) goto fail;
 
                 ffmpeg_data = init_ffmpeg_header_offset(streamFile, buf,bytes, genh.start_offset,genh.data_size);
                 if ( !ffmpeg_data ) goto fail;
@@ -313,8 +312,9 @@ VGMSTREAM * init_vgmstream_genh(STREAMFILE *streamFile) {
             vgmstream->codec_data = ffmpeg_data;
             vgmstream->layout_type = layout_none;
 
-            /* force encoder delay */
-            if (genh.skip_samples_mode && genh.skip_samples >= 0) {
+            if (genh.codec == XMA1 || genh.codec == XMA2) {
+                xma_fix_raw_samples(vgmstream, streamFile, genh.start_offset,genh.data_size, 0, 0,0);
+            } else if (genh.skip_samples_mode && genh.skip_samples >= 0) { /* force encoder delay */
                 ffmpeg_set_skip_samples(ffmpeg_data, genh.skip_samples);
             }
 

--- a/src/meta/gsp_gsb.c
+++ b/src/meta/gsp_gsb.c
@@ -12,7 +12,7 @@ VGMSTREAM * init_vgmstream_gsp_gsb(STREAMFILE *streamFile) {
     int codec_id;
 	
     
-    /* check extensions */
+    /* checks */
     if (!check_extensions(streamFile,"gsb"))
         goto fail;
 
@@ -116,14 +116,13 @@ VGMSTREAM * init_vgmstream_gsp_gsb(STREAMFILE *streamFile) {
             /* 0x00: fmt0x166 header (BE),  0x34: seek table */
 
             bytes = ffmpeg_make_riff_xma_from_fmt_chunk(buf,200, chunk_offset,0x34, datasize, streamHeader, 1);
-            if (bytes <= 0) goto fail;
-
             ffmpeg_data = init_ffmpeg_header_offset(streamFile, buf,bytes, start_offset,datasize);
             if ( !ffmpeg_data ) goto fail;
             vgmstream->codec_data = ffmpeg_data;
             vgmstream->coding_type = coding_FFmpeg;
             vgmstream->layout_type = layout_none;
 
+            xma_fix_raw_samples(vgmstream, streamFile, start_offset,datasize, 0, 0,0); /* samples are ok */
             break;
         }
 #endif

--- a/src/meta/gtd.c
+++ b/src/meta/gtd.c
@@ -94,6 +94,8 @@ VGMSTREAM * init_vgmstream_gtd(STREAMFILE *streamFile) {
             vgmstream->layout_type = layout_none;
 
             vgmstream->num_samples = num_samples;
+
+            xma_fix_raw_samples(vgmstream, streamFile, start_offset, data_size, chunk_offset, 1,1);
             break;
         }
 #endif

--- a/src/meta/hca_keys.h
+++ b/src/meta/hca_keys.h
@@ -261,6 +261,12 @@ static const hcakey_info hcakey_list[] = {
         /* Dragalia Lost (Android) */
         {2967411924141,         subkeys_dgl, sizeof(subkeys_dgl) / sizeof(subkeys_dgl[0]) },    // 000002B2E7889CAD
 
+        /* Libra of Precatus (Android) */
+        {0x6D8EFB700870FCD4},       // 6D8EFB700870FCD4
+
+        /* Mashiro Witch (Android) */
+        {0x55D11D3349495204},       // 55D11D3349495204
+
 };
 
 #endif/*_HCA_KEYS_H_*/

--- a/src/meta/meta.h
+++ b/src/meta/meta.h
@@ -808,4 +808,6 @@ VGMSTREAM * init_vgmstream_nwav(STREAMFILE * streamFile);
 
 VGMSTREAM * init_vgmstream_xpcm(STREAMFILE * streamFile);
 
+VGMSTREAM * init_vgmstream_msf_tamasoft(STREAMFILE * streamFile);
+
 #endif /*_META_H*/

--- a/src/meta/msf_tamasoft.c
+++ b/src/meta/msf_tamasoft.c
@@ -1,0 +1,74 @@
+#include "meta.h"
+#include "../coding/coding.h"
+
+/* MSF - TamaSoft games [Abandoner: The Severed Dreams (PC)] */
+VGMSTREAM * init_vgmstream_msf_tamasoft(STREAMFILE *streamFile) {
+    VGMSTREAM * vgmstream = NULL;
+    off_t start_offset;
+    int loop_flag, channel_count, sample_rate, codec, loop_start = 0, loop_end = 0;
+    size_t data_size;
+    uint16_t xor16;
+    uint32_t xor32;
+
+
+    /* checks */
+    /* .msf: extension referenced in .EXE (bigfiles don't have filenames) */
+    if (!check_extensions(streamFile, "msf"))
+        goto fail;
+
+    if (read_32bitBE(0x00,streamFile) != 0x4D534620) /* "MSF " */
+        goto fail;
+    if (read_32bitBE(0x08,streamFile) != 0x00) /* just in case since there are other .msf */
+        goto fail;
+
+    /* header from 0x10 to 0x30 is encrypted (though value at 0x10 doubles as key...) */
+    xor16 = (uint16_t)(((uint32_t)read_32bitLE(0x04,streamFile) * 0x65u) + 0x30Au); /* from the exe */
+    xor32 = (uint32_t)(((uint32_t)xor16 << 16u) | (uint32_t)xor16);
+
+    /* 0x10: null */
+    loop_flag       = (uint32_t)read_32bitLE(0x14,streamFile) ^ xor32;
+    data_size       = (uint32_t)read_32bitLE(0x18,streamFile) ^ xor32;
+    codec           = (uint16_t)read_16bitLE(0x1c,streamFile) ^ xor16;
+    channel_count   = (uint16_t)read_16bitLE(0x1e,streamFile) ^ xor16;
+    sample_rate     = (uint32_t)read_32bitLE(0x20,streamFile) ^ xor32;
+    /* 0x24: average bitrate? */
+    /* 0x28: block size */
+    /* 0x2a: bps */
+    /* 0x2c: unknown (fixed) */
+
+    if (loop_flag) {
+        loop_start      = read_32bitLE(0x30,streamFile);
+        loop_end        = read_32bitLE(0x34,streamFile);
+        /* 0x38/3c: null */
+        start_offset = 0x40;
+    }
+    else {
+        start_offset = 0x30;
+    }
+
+    if (codec != 0x01)
+        goto fail;
+
+
+    /* build the VGMSTREAM */
+    vgmstream = allocate_vgmstream(channel_count, loop_flag);
+    if (!vgmstream) goto fail;
+
+    vgmstream->meta_type = meta_MSF_TAMASOFT;
+    vgmstream->sample_rate = sample_rate;
+    vgmstream->num_samples = pcm_bytes_to_samples(data_size, channel_count, 16);
+    vgmstream->loop_start_sample = pcm_bytes_to_samples(loop_start, channel_count, 16);
+    vgmstream->loop_end_sample   = pcm_bytes_to_samples(loop_end, channel_count, 16);
+
+    vgmstream->coding_type = coding_PCM16LE;
+    vgmstream->layout_type = layout_interleave;
+    vgmstream->interleave_block_size = 0x02;
+
+    if (!vgmstream_open_stream(vgmstream,streamFile,start_offset))
+        goto fail;
+    return vgmstream;
+
+fail:
+    close_vgmstream(vgmstream);
+    return NULL;
+}

--- a/src/meta/nub_xma.c
+++ b/src/meta/nub_xma.c
@@ -10,10 +10,9 @@ VGMSTREAM * init_vgmstream_nub_xma(STREAMFILE *streamFile) {
     int num_samples, loop_start_sample, loop_end_sample;
 
 
-    /* check extension, case insensitive */
+    /* checks */
     if ( !check_extensions(streamFile,"xma")) /* (probably meant to be .nub) */
         goto fail;
-
     if (read_32bitBE(0x00,streamFile) != 0x786D6100)   /* "xma\0" */
         goto fail;
 
@@ -55,19 +54,17 @@ VGMSTREAM * init_vgmstream_nub_xma(STREAMFILE *streamFile) {
         } else { /* "fmt " */
             bytes = ffmpeg_make_riff_xma_from_fmt_chunk(buf,0x100, chunk_offset,chunk_size, data_size, streamFile, 1);
         }
-        if (bytes <= 0) goto fail;
-
-        vgmstream->codec_data = init_ffmpeg_header_offset(streamFile, buf,bytes, start_offset,data_size);;
+        vgmstream->codec_data = init_ffmpeg_header_offset(streamFile, buf,bytes, start_offset,data_size);
         if ( !vgmstream->codec_data ) goto fail;
         vgmstream->coding_type = coding_FFmpeg;
         vgmstream->layout_type = layout_none;
+
+        xma_fix_raw_samples(vgmstream, streamFile, start_offset, data_size, chunk_offset, 1,1); /* samples needs adjustment */
     }
 #else
     goto fail;
 #endif
 
-
-    /* open the file for reading */
     if ( !vgmstream_open_stream(vgmstream, streamFile, start_offset) )
         goto fail;
     return vgmstream;

--- a/src/meta/p3d.c
+++ b/src/meta/p3d.c
@@ -11,11 +11,9 @@ VGMSTREAM * init_vgmstream_p3d(STREAMFILE *streamFile) {
     int32_t (*read_32bit)(off_t,STREAMFILE*) = NULL;
 
 
-    /* check extension, case insensitive */
+    /* checks */
     if (!check_extensions(streamFile,"p3d"))
         goto fail;
-
-    /* check header */
     if (read_32bitBE(0x0,streamFile) != 0x503344FF &&  /* "P3D"\FF (LE: PC) */
         read_32bitBE(0x0,streamFile) != 0xFF443350)    /* \FF"D3P" (BE: PS3, X360) */
         goto fail;
@@ -164,12 +162,12 @@ VGMSTREAM * init_vgmstream_p3d(STREAMFILE *streamFile) {
             size_t bytes;
 
             bytes = ffmpeg_make_riff_xma2(buf,0x100, vgmstream->num_samples, data_size, vgmstream->channels, vgmstream->sample_rate, block_count, block_size);
-            if (bytes <= 0) goto fail;
-
             vgmstream->codec_data = init_ffmpeg_header_offset(streamFile, buf,bytes, start_offset,data_size);
             if ( !vgmstream->codec_data ) goto fail;
             vgmstream->coding_type = coding_FFmpeg;
             vgmstream->layout_type = layout_none;
+
+            xma_fix_raw_samples(vgmstream, streamFile, start_offset, data_size, 0, 1,1); /* samples needs adjustment */
             break;
         }
 #endif

--- a/src/meta/pona.c
+++ b/src/meta/pona.c
@@ -1,127 +1,91 @@
 #include "meta.h"
-#include "../util.h"
+#include "../coding/coding.h"
 
-/* PONA (from Policenauts [3DO]) */
+/* PONA - from Policenauts (3DO) */
 VGMSTREAM * init_vgmstream_pona_3do(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
-    char filename[PATH_LIMIT];
     off_t start_offset;
-    int loop_flag;
-	  int channel_count;
+    int loop_flag, channel_count;
 
-    /* check extension, case insensitive */
-    streamFile->get_name(streamFile,filename,sizeof(filename));
-    if (strcasecmp("pona",filename_extension(filename))) goto fail;
 
-    /* check header */
+    /* checks */
+    /* .pona: fake extension?
+     * .sxd: Policenauts Pilot Disc (3DO) */
+    if (!check_extensions(streamFile, "pona,sxd"))
+        goto fail;
     if (read_32bitBE(0x00,streamFile) != 0x13020000)
         goto fail;
-    
-    if ((read_32bitBE(0x06,streamFile)+0x800) != (get_streamfile_size(streamFile)))
+    if (read_32bitBE(0x06,streamFile)+0x800 != get_streamfile_size(streamFile))
         goto fail;
     
     loop_flag = (read_32bitBE(0x0A,streamFile) != 0xFFFFFFFF);
     channel_count = 1;
-    
-	  /* build the VGMSTREAM */
+    start_offset = (uint16_t)(read_16bitBE(0x04,streamFile));
+
+
+    /* build the VGMSTREAM */
     vgmstream = allocate_vgmstream(channel_count,loop_flag);
     if (!vgmstream) goto fail;
 
-	  /* fill in the vital statistics */
-    start_offset = (uint16_t)(read_16bitBE(0x04,streamFile));
-	  vgmstream->channels = channel_count;
-    vgmstream->sample_rate = 22050;
-    vgmstream->coding_type = coding_SDX2;
-    vgmstream->num_samples = (get_streamfile_size(streamFile))-start_offset;
-    if (loop_flag) {
-        vgmstream->loop_start_sample = (read_32bitBE(0x0A,streamFile));
-        vgmstream->loop_end_sample = (read_32bitBE(0x06,streamFile));
-    }
-
-    vgmstream->layout_type = layout_none;
     vgmstream->meta_type = meta_PONA_3DO;
-
-    /* open the file for reading */
-    {
-        int i;
-        STREAMFILE * file;
-        file = streamFile->open(streamFile,filename,STREAMFILE_DEFAULT_BUFFER_SIZE);
-        if (!file) goto fail;
-        for (i=0;i<channel_count;i++) {
-            vgmstream->ch[i].streamfile = file;
-            vgmstream->ch[i].channel_start_offset=
-                vgmstream->ch[i].offset=start_offset+
-                vgmstream->interleave_block_size*i;
-        }
+    vgmstream->sample_rate = 22050;
+    vgmstream->num_samples = get_streamfile_size(streamFile) - start_offset;
+    if (loop_flag) {
+        vgmstream->loop_start_sample = read_32bitBE(0x0A,streamFile);
+        vgmstream->loop_end_sample = read_32bitBE(0x06,streamFile);
     }
+    vgmstream->coding_type = coding_SDX2;
+    vgmstream->layout_type = layout_none;
 
+    if ( !vgmstream_open_stream(vgmstream, streamFile, start_offset) )
+        goto fail;
     return vgmstream;
 
-    /* clean up anything we may have opened */
 fail:
-    if (vgmstream) close_vgmstream(vgmstream);
+    close_vgmstream(vgmstream);
     return NULL;
 }
 
 
-/* PONA (from Policenauts [PSX]) */
+/* PONA - from Policenauts (PSX) */
 VGMSTREAM * init_vgmstream_pona_psx(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
-    char filename[PATH_LIMIT];
     off_t start_offset;
-    int loop_flag;
-	  int channel_count;
+    int loop_flag, channel_count;
 
-    /* check extension, case insensitive */
-    streamFile->get_name(streamFile,filename,sizeof(filename));
-    if (strcasecmp("pona",filename_extension(filename))) goto fail;
-
-    /* check header */
+    /* checks */
+    /* .pona: fake extension? */
+    if (!check_extensions(streamFile, "pona"))
+        goto fail;
     if (read_32bitBE(0x00,streamFile) != 0x00000800)
         goto fail;
-
-    if ((read_32bitBE(0x08,streamFile)+0x800) != (get_streamfile_size(streamFile)))
+    if (read_32bitBE(0x08,streamFile)+0x800 != get_streamfile_size(streamFile))
         goto fail;
 
     loop_flag = (read_32bitBE(0xC,streamFile) != 0xFFFFFFFF);
     channel_count = 1;
-    
-	  /* build the VGMSTREAM */
+    start_offset = read_32bitBE(0x04,streamFile);
+
+
+    /* build the VGMSTREAM */
     vgmstream = allocate_vgmstream(channel_count,loop_flag);
     if (!vgmstream) goto fail;
 
-	  /* fill in the vital statistics */
-    start_offset = read_32bitBE(0x04,streamFile);
-	  vgmstream->channels = channel_count;
-    vgmstream->sample_rate = 44100;
-    vgmstream->coding_type = coding_PSX;
-    vgmstream->num_samples = ((get_streamfile_size(streamFile))-start_offset)/16/channel_count*28;
-    if (loop_flag) {
-        vgmstream->loop_start_sample = (read_32bitBE(0x0C,streamFile)/16/channel_count*28);
-        vgmstream->loop_end_sample = (read_32bitBE(0x08,streamFile)/16/channel_count*28);
-    }
-
-    vgmstream->layout_type = layout_none;
     vgmstream->meta_type = meta_PONA_PSX;
-
-    /* open the file for reading */
-    {
-        int i;
-        STREAMFILE * file;
-        file = streamFile->open(streamFile,filename,STREAMFILE_DEFAULT_BUFFER_SIZE);
-        if (!file) goto fail;
-        for (i=0;i<channel_count;i++) {
-            vgmstream->ch[i].streamfile = file;
-            vgmstream->ch[i].channel_start_offset=
-                vgmstream->ch[i].offset=start_offset+
-                vgmstream->interleave_block_size*i;
-        }
+    vgmstream->sample_rate = 44100;
+    vgmstream->num_samples = ps_bytes_to_samples(get_streamfile_size(streamFile) - start_offset, channel_count);
+    if (loop_flag) {
+        vgmstream->loop_start_sample = ps_bytes_to_samples(read_32bitBE(0x0C,streamFile), channel_count);
+        vgmstream->loop_end_sample = ps_bytes_to_samples(read_32bitBE(0x08,streamFile), channel_count);
     }
+    vgmstream->coding_type = coding_PSX;
+    vgmstream->layout_type = layout_none;
 
+    if ( !vgmstream_open_stream(vgmstream, streamFile, start_offset) )
+        goto fail;
     return vgmstream;
 
-    /* clean up anything we may have opened */
 fail:
-    if (vgmstream) close_vgmstream(vgmstream);
+    close_vgmstream(vgmstream);
     return NULL;
 }

--- a/src/meta/rsd.c
+++ b/src/meta/rsd.c
@@ -1025,13 +1025,15 @@ VGMSTREAM * init_vgmstream_rsd6xma(STREAMFILE *streamFile) {
 			datasize = read_32bitBE(0x808, streamFile);
 
 			bytes = ffmpeg_make_riff_xma2(buf, 100, vgmstream->num_samples, datasize, vgmstream->channels, vgmstream->sample_rate, block_count, block_size);
-			if (bytes <= 0) goto fail;
-
 			ffmpeg_data = init_ffmpeg_header_offset(streamFile, buf, bytes, start_offset, datasize);
 			if (!ffmpeg_data) goto fail;
 			vgmstream->codec_data = ffmpeg_data;
 			vgmstream->coding_type = coding_FFmpeg;
 			vgmstream->layout_type = layout_none;
+
+			/* for some reason (dev trickery?) .rsd don't set skip in the bitstream, though they should */
+            //xma_fix_raw_samples(vgmstream, streamFile, start_offset,datasize, 0, 0,0);
+            ffmpeg_set_skip_samples(ffmpeg_data, 512+64);
 		}
 #else
 		goto fail;
@@ -1053,13 +1055,15 @@ VGMSTREAM * init_vgmstream_rsd6xma(STREAMFILE *streamFile) {
 			datasize = read_32bitBE(0x808, streamFile);
 
 			bytes = ffmpeg_make_riff_xma2(buf, 100, vgmstream->num_samples, datasize, vgmstream->channels, vgmstream->sample_rate, block_count, block_size);
-			if (bytes <= 0) goto fail;
-
 			ffmpeg_data = init_ffmpeg_header_offset(streamFile, buf, bytes, start_offset, datasize);
 			if (!ffmpeg_data) goto fail;
 			vgmstream->codec_data = ffmpeg_data;
 			vgmstream->coding_type = coding_FFmpeg;
 			vgmstream->layout_type = layout_none;
+
+            /* for some reason (dev trickery?) .rsd don't set skip in the bitstream, though they should */
+            //xma_fix_raw_samples(vgmstream, streamFile, start_offset,datasize, 0, 0,0);
+            ffmpeg_set_skip_samples(ffmpeg_data, 512+64);
 		}
 #else
 		goto fail;

--- a/src/meta/seg.c
+++ b/src/meta/seg.c
@@ -92,6 +92,8 @@ VGMSTREAM * init_vgmstream_seg(STREAMFILE *streamFile) {
             if (!vgmstream->codec_data) goto fail;
             vgmstream->coding_type = coding_FFmpeg;
             vgmstream->layout_type = layout_none;
+
+            xma_fix_raw_samples(vgmstream, streamFile, start_offset,data_size, 0, 0,0); /* samples are ok */
             break;
         }
 #endif

--- a/src/meta/sqex_scd.c
+++ b/src/meta/sqex_scd.c
@@ -334,23 +334,23 @@ VGMSTREAM * init_vgmstream_sqex_scd(STREAMFILE *streamFile) {
 
 #ifdef VGM_USE_FFMPEG
         case 0x0B: {    /* XMA2 [Final Fantasy (X360), Lightning Returns (X360) sfx, Kingdom Hearts 2.8 (X1)] */
-                ffmpeg_codec_data *ffmpeg_data = NULL;
-                uint8_t buf[200];
-                int32_t bytes;
+            ffmpeg_codec_data *ffmpeg_data = NULL;
+            uint8_t buf[200];
+            int32_t bytes;
 
-                /* extradata_offset+0x00: fmt0x166 header (BE),  extradata_offset+0x34: seek table */
-                bytes = ffmpeg_make_riff_xma_from_fmt_chunk(buf,200, extradata_offset,0x34, stream_size, streamFile, 1);
-                if (bytes <= 0) goto fail;
+            /* extradata_offset+0x00: fmt0x166 header (BE),  extradata_offset+0x34: seek table */
+            bytes = ffmpeg_make_riff_xma_from_fmt_chunk(buf,200, extradata_offset,0x34, stream_size, streamFile, 1);
+            ffmpeg_data = init_ffmpeg_header_offset(streamFile, buf,bytes, start_offset,stream_size);
+            if (!ffmpeg_data) goto fail;
+            vgmstream->codec_data = ffmpeg_data;
+            vgmstream->coding_type = coding_FFmpeg;
+            vgmstream->layout_type = layout_none;
 
-                ffmpeg_data = init_ffmpeg_header_offset(streamFile, buf,bytes, start_offset,stream_size);
-                if (!ffmpeg_data) goto fail;
-                vgmstream->codec_data = ffmpeg_data;
-                vgmstream->coding_type = coding_FFmpeg;
-                vgmstream->layout_type = layout_none;
+            vgmstream->num_samples = ffmpeg_data->totalSamples;
+            vgmstream->loop_start_sample = loop_start;
+            vgmstream->loop_end_sample = loop_end;
 
-                vgmstream->num_samples = ffmpeg_data->totalSamples;
-                vgmstream->loop_start_sample = loop_start;
-                vgmstream->loop_end_sample = loop_end;
+            xma_fix_raw_samples(vgmstream, streamFile, start_offset,stream_size, 0, 0,0); /* samples are ok, loops? */
             break;
         }
 

--- a/src/meta/ta_aac.c
+++ b/src/meta/ta_aac.c
@@ -108,13 +108,17 @@ VGMSTREAM * init_vgmstream_ta_aac_x360(STREAMFILE *streamFile) {
         datasize = dataSize;
 
         bytes = ffmpeg_make_riff_xma2(buf,100, vgmstream->num_samples, datasize, vgmstream->channels, vgmstream->sample_rate, block_count, block_size);
-        if (bytes <= 0) goto fail;
-
         ffmpeg_data = init_ffmpeg_header_offset(streamFile, buf,bytes, start_offset,datasize);
         if ( !ffmpeg_data ) goto fail;
         vgmstream->codec_data = ffmpeg_data;
         vgmstream->coding_type = coding_FFmpeg;
         vgmstream->layout_type = layout_none;
+
+        xma_fix_raw_samples(vgmstream, streamFile, start_offset, datasize, 0, 1,1);
+        if (loop_flag) { /* reapply adjusted samples */
+            vgmstream->loop_end_sample = vgmstream->num_samples;
+        }
+
     }
 #else
     goto fail;

--- a/src/meta/txth.c
+++ b/src/meta/txth.c
@@ -335,7 +335,6 @@ VGMSTREAM * init_vgmstream_txth(STREAMFILE *streamFile) {
                 else {
                     goto fail;
                 }
-                if (bytes <= 0) goto fail;
 
                 ffmpeg_data = init_ffmpeg_header_offset(streamFile, buf,bytes, txth.start_offset,txth.data_size);
                 if ( !ffmpeg_data ) goto fail;
@@ -344,8 +343,9 @@ VGMSTREAM * init_vgmstream_txth(STREAMFILE *streamFile) {
             vgmstream->codec_data = ffmpeg_data;
             vgmstream->layout_type = layout_none;
 
-            /* force encoder delay */
-            if (txth.skip_samples_set) {
+            if (txth.codec == XMA1 || txth.codec == XMA2) {
+                xma_fix_raw_samples(vgmstream, streamFile, txth.start_offset,txth.data_size, 0, 0,0);
+            } else if (txth.skip_samples_set) { /* force encoder delay */
                 ffmpeg_set_skip_samples(ffmpeg_data, txth.skip_samples);
             }
 

--- a/src/meta/ubi_bao.c
+++ b/src/meta/ubi_bao.c
@@ -190,6 +190,8 @@ static VGMSTREAM * init_vgmstream_ubi_bao_main(ubi_bao_header * bao, STREAMFILE 
             vgmstream->layout_type = layout_none;
 
             vgmstream->stream_size = data_size;
+
+            xma_fix_raw_samples(vgmstream, streamData, start_offset,data_size, 0, 0,0);
             break;
         }
 

--- a/src/meta/vawx.c
+++ b/src/meta/vawx.c
@@ -36,9 +36,9 @@ VGMSTREAM * init_vgmstream_vawx(STREAMFILE *streamFile) {
     vgmstream->meta_type = meta_VAWX;
 
     switch(codec) {
-        case 2: /* VAG */
+        case 2: /* PS-ADPCM */
             vgmstream->coding_type = coding_PSX;
-            vgmstream->layout_type = channel_count == 6 ? layout_blocked_vawx : layout_interleave ;
+            vgmstream->layout_type = channel_count == 6 ? layout_blocked_vawx : layout_interleave;
             vgmstream->interleave_block_size = 0x10;
 
             vgmstream->loop_start_sample = read_32bitBE(0x44,streamFile);
@@ -66,6 +66,8 @@ VGMSTREAM * init_vgmstream_vawx(STREAMFILE *streamFile) {
             vgmstream->loop_start_sample = read_32bitBE(0x44,streamFile);
             vgmstream->loop_end_sample = read_32bitBE(0x48,streamFile);
 
+            /* may be only applying end_skip to num_samples? */
+            xma_fix_raw_samples(vgmstream, streamFile, start_offset,data_size, 0, 0,0);
             break;
         }
 

--- a/src/meta/wwise.c
+++ b/src/meta/wwise.c
@@ -147,13 +147,14 @@ VGMSTREAM * init_vgmstream_wwise(STREAMFILE *streamFile) {
     switch(ww.format) {
         case 0x0001: ww.codec = PCM; break; /* older Wwise */
         case 0x0002: ww.codec = IMA; break; /* newer Wwise (conflicts with MSADPCM, probably means "platform's ADPCM") */
-        //case 0x0011: ww.codec = IMA; break; /* older Wwise (used?) */
+      //case 0x0011: ww.codec = IMA; break; /* older Wwise (used?) */
         case 0x0069: ww.codec = IMA; break; /* older Wwise (Spiderman Web of Shadows X360, LotR Conquest PC) */
         case 0x0161: ww.codec = XWMA; break; /* WMAv2 */
         case 0x0162: ww.codec = XWMA; break; /* WMAPro */
         case 0x0165: ww.codec = XMA2; break; /* always with the "XMA2" chunk, Wwise doesn't use XMA1 */
         case 0x0166: ww.codec = XMA2; break;
-        case 0x3039: ww.codec = OPUS; break;
+        case 0x3039: ww.codec = OPUS; break; /* later renamed to "OPUSNX" */
+      //case 0x3040: ww.codec = OPUS; break; /* same for other platforms, supposedly */
         case 0xAAC0: ww.codec = AAC; break;
         case 0xFFF0: ww.codec = DSP; break;
         case 0xFFFB: ww.codec = HEVAG; break;
@@ -511,7 +512,7 @@ VGMSTREAM * init_vgmstream_wwise(STREAMFILE *streamFile) {
             break;
         }
 
-        case OPUS: {    /* Switch */
+        case OPUS: {  /* Switch */
             size_t skip;
 
             /* values up to 0x14 seem fixed and similar to HEVAG's (block_align 0x02/04, bits_per_sample 0x10) */

--- a/src/meta/x360_ast.c
+++ b/src/meta/x360_ast.c
@@ -55,7 +55,6 @@ VGMSTREAM * init_vgmstream_x360_ast(STREAMFILE *streamFile) {
         vgmstream->num_samples = msd.num_samples;
         vgmstream->loop_start_sample = msd.loop_start_sample;
         vgmstream->loop_end_sample = msd.loop_end_sample;
-        //skip_samples = msd.skip_samples; //todo add skip samples
     }
 
 #ifdef VGM_USE_FFMPEG
@@ -68,12 +67,12 @@ VGMSTREAM * init_vgmstream_x360_ast(STREAMFILE *streamFile) {
 
         /* XMA1 "fmt" chunk @ 0x20 (BE, unlike the usual LE) */
         bytes = ffmpeg_make_riff_xma_from_fmt_chunk(buf,100, fmt_offset,fmt_size, data_size, streamFile, 1);
-        if (bytes <= 0) goto fail;
-
         vgmstream->codec_data = init_ffmpeg_header_offset(streamFile, buf,bytes, start_offset,data_size);
         if ( !vgmstream->codec_data ) goto fail;
         vgmstream->coding_type = coding_FFmpeg;
         vgmstream->layout_type = layout_none;
+
+        xma_fix_raw_samples(vgmstream, streamFile, start_offset, data_size, fmt_offset, 1,1);
     }
 #else
     goto fail;

--- a/src/meta/x360_pasx.c
+++ b/src/meta/x360_pasx.c
@@ -10,10 +10,9 @@ VGMSTREAM * init_vgmstream_x360_pasx(STREAMFILE *streamFile) {
     int num_samples, loop_start_sample, loop_end_sample;
 
 
-    /* check extension, case insensitive */
+    /* checks */
     if ( !check_extensions(streamFile,"past"))
         goto fail;
-
     if (read_32bitBE(0x00,streamFile) != 0x50415358)   /* "PASX" */
         goto fail;
 
@@ -51,6 +50,8 @@ VGMSTREAM * init_vgmstream_x360_pasx(STREAMFILE *streamFile) {
         if ( !vgmstream->codec_data ) goto fail;
         vgmstream->coding_type = coding_FFmpeg;
         vgmstream->layout_type = layout_none;
+
+        xma_fix_raw_samples(vgmstream, streamFile, start_offset, data_size, chunk_offset, 1,1);
     }
 #else
     goto fail;

--- a/src/meta/xma.c
+++ b/src/meta/xma.c
@@ -1,7 +1,7 @@
 #include "meta.h"
 #include "../coding/coding.h"
 
-/* XMA - Microsoft format derived from WMAPRO, found in X360/XBone games */
+/* XMA - Microsoft format derived from RIFF, found in X360/XBone games */
 VGMSTREAM * init_vgmstream_xma(STREAMFILE *streamFile) {
     VGMSTREAM * vgmstream = NULL;
     off_t start_offset, chunk_offset, first_offset = 0xc;
@@ -69,7 +69,7 @@ VGMSTREAM * init_vgmstream_xma(STREAMFILE *streamFile) {
         goto fail;
 
 
-    /* fix samples; for now only XMA1 is fixed, but XMA2 num_samples don't include skip samples and xmaencode.exe doesn't use it */
+    /* get xma1 samples, later fixed */
     if (is_xma1) {
         ms_sample_data msd = {0};
 
@@ -96,12 +96,11 @@ VGMSTREAM * init_vgmstream_xma(STREAMFILE *streamFile) {
     vgmstream = allocate_vgmstream(channel_count,loop_flag);
     if (!vgmstream) goto fail;
 
+    vgmstream->meta_type = meta_XMA_RIFF;
     vgmstream->sample_rate = sample_rate;
     vgmstream->num_samples = num_samples;
     vgmstream->loop_start_sample = loop_start_sample;
     vgmstream->loop_end_sample   = loop_end_sample;
-    vgmstream->meta_type = meta_XMA_RIFF;
-
 
 #ifdef VGM_USE_FFMPEG
     {
@@ -118,6 +117,8 @@ VGMSTREAM * init_vgmstream_xma(STREAMFILE *streamFile) {
         if ( !vgmstream->codec_data ) goto fail;
         vgmstream->coding_type = coding_FFmpeg;
         vgmstream->layout_type = layout_none;
+
+        xma_fix_raw_samples(vgmstream, streamFile, start_offset, data_size, chunk_offset, 1,1);
     }
 #else
     goto fail;

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -22,12 +22,17 @@ typedef struct {
     off_t section_start;
     off_t section_end;
     off_t offset;
+
+    /* commands */
+    int autotrack_on;
+    int autotrack_written;
+    int track_count;
 } VGMSTREAM_TAGS;
 
 
 
 /* Extracts next valid tag in tagfile to *tag. Returns 0 if no more tags are found (meant to be
- * called repeatedly until 0). Key are lowercase and values can be treated as UTF-8. */
+ * called repeatedly until 0). Key/values are trimmed and values can be in UTF-8. */
 int vgmstream_tags_next_tag(VGMSTREAM_TAGS* tag, STREAMFILE* tagfile);
 
 /* resets tagfile to restart reading from the beginning for a new filename */

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -449,6 +449,7 @@ VGMSTREAM * (*init_vgmstream_functions[])(STREAMFILE *streamFile) = {
     init_vgmstream_msf_banpresto_2msf,
     init_vgmstream_nwav,
     init_vgmstream_xpcm,
+    init_vgmstream_msf_tamasoft,
 
     /* lowest priority metas (should go after all metas, and TXTH should go before raw formats) */
     init_vgmstream_txth,            /* proper parsers should supersede TXTH, once added */

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -705,6 +705,7 @@ typedef enum {
     meta_VS_FFX,
     meta_NWAV,
     meta_XPCM,
+    meta_MSF_TAMASOFT,
 
 } meta_t;
 


### PR DESCRIPTION
- Fix bad loops in pce2p_bgm_ajurika_*.fsb [Pac-Man CE2 Plus (Switch)]
- Add HCA/ADX keys
- Fix some AKB AAC issues, add doc (from lib)
- Add TamaSoft .msf [Abandoner: The Severed Dreams (PC)]
- Add !tags.m3u $AUTOTRACK command for auto %TRACK% tag
- Fix XMA gapless/looping/samples
  fixes: standard, wem, xwc, xwb, xnb, xwx, rak, pk, txth, genh, seg, rsd, past, p3d, nub-xma, gtd, gsp, fsb, eaac, cxs, awc, aac
- Add PONA .sxd extension [Policenauts Pilot Disc (3DO)]
