### PR TITLE
txth

### DIFF
--- a/doc/TXTH.md
+++ b/doc/TXTH.md
@@ -2,7 +2,7 @@
 
 TXTH is a simple text file that uses text commands to simulate a header for files unsupported by vgmstream, mainly headerless audio.
 
-When an unsupported file is loaded, vgmstream tries to find a TXTH header in the same dir, in this order:
+When an unsupported file is loaded (for instance "bgm01.snd"), vgmstream tries to find a TXTH header in the same dir, in this order:
 - (filename.ext).txth
 - .(ext).txth
 - .txth
@@ -31,16 +31,16 @@ A text file with the above commands must be saved as ".vag.txth" or ".txth", not
 ```
 ######################################################
 
-# comments start with #, can be inline
 # The file is made lines of "key = value" describing a header.
-# Spaces are optional: key=value, key=   value, and so on are all ok.
+# Comments start with #, can be inlined.
+# Spaces are optional: key=value, key  =   value, and so on are all ok.
 # The parser is fairly simple and may be buggy or unexpected in some cases.
 # The order of keys is variable but some things won't work if others aren't defined
 # (ex. bytes-to-samples may not work without channels or interleave).
 
 # Common values:
 # - (number): constant number in dec/hex.
-#   Examples: 44100, 40, 0x40 (dec=64)
+#   Examples: 44100, 40, 0x40 (decimal=64)
 # - (offset): format is @(number)[:LE|BE][$1|2|3|4]
 #   * @(number): value at offset (required)
 #   * :LE|BE: value is little/big endian (optional, defaults to LE)
@@ -52,73 +52,76 @@ A text file with the above commands must be saved as ".vag.txth" or ".txth", not
 # Accepted codec strings:
 # - PSX            PlayStation ADPCM
 # - XBOX           Xbox IMA ADPCM
-# - NGC_DTK        Nintendo ADP/DTK ADPCM
-# - PCM16BE        PCM RAW 16bit big endian
-# - PCM16LE        PCM RAW 16bit little endian
-# - PCM8           PCM RAW 8bit
+# - NGC_DTK|DTK    Nintendo ADP/DTK ADPCM
+# - PCM16BE        PCM 16-bit big endian
+# - PCM16LE        PCM 16-bit little endian
+# - PCM8           PCM 8-bit
 # - SDX2           Squareroot-delta-exact 8-bit DPCM (3DO games)
 # - DVI_IMA        DVI IMA ADPCM
-# - MPEG           MPEG Audio Layer File (MP1/2/3)
+# - MPEG           MPEG Audio Layer file (MP1/2/3)
 # - IMA            IMA ADPCM
 # - AICA           Yamaha AICA ADPCM (Dreamcast)
 # - MSADPCM        Microsoft ADPCM (Windows)
-# - NGC_DSP        Nintendo GameCube ADPCM
+# - NGC_DSP|DSP    Nintendo GameCube ADPCM
 # - PCM8_U_int     PCM RAW 8bit unsigned (interleaved)
 # - PSX_bf         PlayStation ADPCM with bad flags
 # - MS_IMA         Microsoft IMA ADPCM
-# - PCM8_U         PCM RAW 8bit unsigned
+# - PCM8_U         PCM 8-bit unsigned
 # - APPLE_IMA4     Apple Quicktime IMA ADPCM
-# - ATRAC3         raw ATRAC3
-# - ATRAC3PLUS     raw ATRAC3PLUS
-# - XMA1           raw XMA1
-# - XMA2           raw XMA2
-# - FFMPEG         any headered FFmpeg format
+# - ATRAC3         Sony ATRAC3
+# - ATRAC3PLUS     Sony ATRAC3plus
+# - XMA1           Microsoft XMA1
+# - XMA2           Microsoft XMA2
+# - FFMPEG         Any headered FFmpeg format
+# - AC3            AC3/SPDIF
 codec = (codec string)
- 
-# Varies with codec:
+
+# Codec variations [OPTIONAL, depends on codec]
 # - NGC_DSP: 0=normal interleave, 1=byte interleave, 2=no interleave
 # - ATRAC3: 0=autodetect joint stereo, 1=force joint stereo, 2=force normal stereo
 # - XMA1|XMA2: 0=dual multichannel (2ch xN), 1=single multichannel (1ch xN)
 # - XBOX: 0=standard (mono or stereo interleave), 1=force mono interleave mode
 # - others: ignored
 codec_mode = (number)
- 
+
+# Multiplies any next read values [OPTIONAL]
+# Will change to "(key) = (number)|(offset) * value_multiplier",
+# useful if a size is given in 0x800 sectors or such.
+# Should be set to 0 when done using, as it affects ANY value.
+value_multiplier = (number)|(offset)
+
 # Interleave or block size [REQUIRED/OPTIONAL, depends on codec]
-# For mono/interleaved codecs it's the amount of data between channels.
-# For codecs with variable-sized frames (MSADPCM, MS-IMA, ATRAC3/plus)
-# it's the block size (size of a single frame).
+# - half_size: sets interleave as data_size / channels
+# For mono/interleaved codecs it's the amount of data between channels,
+# and for codecs with variable-sized frames (MSADPCM, MS-IMA, ATRAC3/plus)
+# means block size (size of a single frame).
 # Interleave 0 means "stereo mode" for some codecs (IMA, AICA, etc).
-interleave = (number)|(offset)
+interleave = (number)|(offset)|half_size
 
 # Validate that id_value matches value at id_offset [OPTIONAL]
 # Can be redefined several times, it's checked whenever a new id_offset is found.
 id_value = (number)|(offset)
 id_offset = (number)|(offset)
- 
+
 # Number of channels [REQUIRED]
 channels = (number)|(offset)
- 
+
 # Music frequency in hz [REQUIRED]
 sample_rate = (number)|(offset)
- 
+
 # Data start [OPTIONAL, default to 0]
 start_offset = (number)|(offset)
- 
+
 # Variable that can be used in sample values [OPTIONAL]
-# Defaults to (file_size - start_offset), re-calculated when start_offset is set.
+# Defaults to (file_size - start_offset), re-calculated when start_offset
+# is set (won't recalculate if data_size is set then start_offset changes).
 data_size = (number)|(offset)
- 
- 
+
 # Modifies the meaning of sample fields when set *before* them [OPTIONAL, defaults to samples]
 # - samples: exact sample
 # - bytes: automatically converts bytes/offset to samples
 # - blocks: same as bytes, but value is given in blocks/frames
 #   Value is internally converted from blocks to bytes first: bytes = (value * interleave*channels)
-# It's possible to re-define values multiple times:
-#  * samples_type=bytes ... num_samples=@0x10
-#  * samples_type=sample ... loop_end_sample=@0x14
-# Sometimes "bytes" values are given for a single channel only. In that case you can temporally set 1 channel
-#  * channels=1 ... sample_type=bytes ... num_samples=@0x10 ... channels=2
 # Some codecs can't convert bytes-to-samples at the moment: MPEG/FFMPEG
 # For XMA1/2 bytes does special parsing, with loop values being bit offsets within data.
 sample_type = samples|bytes|blocks
@@ -128,29 +131,124 @@ num_samples         = (number)|(offset)|data_size
 loop_start_sample   = (number)|(offset)
 loop_end_sample     = (number)|(offset)|data_size
 
-# For XMA1/2 + sample_type=bytes it means loop subregion, if read after loop values.
-# For other codecs its added to loop start/end, if read before loop values
-# (rarely a format may have rough loop offset/bytes, then a loop adjust in samples).
-loop_adjust = (number)|(offset)
-
 # Force loop, on (>0) or off (0), as loop start/end may be defined but not used [OPTIONAL]
+# - auto: tries to autodetect loop points for PS-ADPCM data, which may include loop flags.
 # By default it loops when loop_end_sample is defined
-# auto tries to autodetect loop points for PS-ADPCM data, which may include loop flags.
 loop_flag = (number)|(offset)|auto
 
-# beginning samples to skip (encoder delay), for codecs that need them (ATRAC3/XMA/etc)
+# Loop start/end modifier [OPTIONAL]
+# For XMA1/2 + sample_type=bytes it means loop subregion, if read after loop values.
+# For other codecs its added to loop start/end, if read before loop values
+# (a format may rarely have rough loop offset/bytes, then a loop adjust in samples).
+loop_adjust = (number)|(offset)
+
+# Beginning samples to skip (encoder delay) [OPTIONAL]
+# Only some codecs use them (ATRAC3/ATRAC3PLUS/XMA/FFMPEG/AC3)
 skip_samples = (number)|(offset)
 
 
-# DSP coefficients [REQUIRED for NGC_DSP]
-# Coefs start
+# DSP decoding coefficients [REQUIRED for NGC_DSP]
+# These coefs are a list of 8*2 16-bit values per channel, starting from offset.
 coef_offset = (number)|(offset)
-# offset separation per channel, usually 0x20
-# - Example: channel N coefs are read at coef_offset + coef_spacing * N
+# Offset separation per channel, usually 0x20 (16 values * 2 bytes)
+# Channel N coefs are read at coef_offset + coef_spacing * N
 coef_spacing = (number)|(offset)
 # Format, usually BE; with (offset): 0=LE, >0=BE
 coef_endianness = BE|LE|(offset)
 # Split/normal coefs [NOT IMPLEMENTED YET]
 #coef_mode = (number)|(offset)
 
+
+# Change header/body to external files [OPTIONAL]
+# TXTH commands are done on a "header", and decoding on "body".
+# When loading an unsupported file it becomes the "base" file
+# that loads the .txth, and is both header and body.
+#
+# You can alter those, mainly for files that split header and body
+# in separate files (load base file and txth sets header on another file).
+# It's also possible to load the .txth directly with a set body, as a sort of
+# "reverse TXTH" (useful with bigfiles, as you could have one .txth per song).
+#
+# Allowed values:
+# - (filename): open any file, subdirs also work (dir/filename)
+# - *.(extension): opens with same name as the "base" file plus another extension
+# - null: unloads file and goes back to defaults (body/header = base file).
+header_file = (filename)|*.(extension)|null
+body_file = (filename)|*.(extension)|null
+
+# Subsongs [OPTIONAL]
+# Sets the number of subsongs in the file, adjusting reads per subsong N:
+# "value = @(offset) + subsong_offset*N". Mainly for bigfiles with consecutive
+# headers per subsong, set subsong_offset to 0 when done as it affects any reads.
+# The current subsong number is handled externally by plugins or TXTP.
+subsong_count = (number)|(offset)
+subsong_offset = (number)|(offset)
+```
+
+## Usages
+
+### Temporary values
+Most commands are evaluated and calculated immediatedly, every time they are found. This is by design, as it can be used to adjust and trick for certain calculations.
+
+For example, normally you are given a data_size in bytes, that can be used to calculate num_samples for all channels.
+```
+channels = 2
+sample_type = bytes
+num_samples = @0x10     #calculated from data_size
+```
+
+But sometimes this size is for a single channel only (even though the file may be stereo). You can set temporally change the channel number to force a correct calculation.
+```
+channels = 1            #not the actual number of channels
+sample_type = bytes
+num_samples = @0x10     #calculated from channel_size
+channels = 2            #change once calculations are done
+```
+
+### Redefining values
+Some commands alter the function of all next commands and can be redefined as needed:
+```
+samples_type = bytes
+num_samples = @0x10
+
+samples_type = sample
+loop_end_sample = @0x14
+```
+
+### External files
+When setting external files all commands are done on the "header" file, but with some creativity you can read in multiple files.
+```
+body_file = bgm01.bdy
+header_file = bgm01.hdr
+channels = @0x10        #base info in bgm01.hdr
+header_file = bgm01.bdy
+coef_offset = 0x00      #DSP coefs in bgm01.bdy
+```
+Note that DSP coefs are special in that aren't read immediately, and will use *last* header_file set.
+
+
+### Resetting values
+Values may need to be reset (to 0 or other sensible value) when done. Subsong example:
+```
+subsong_count = 5
+subsong_offset = 0x20   # there are 5 subsong headers, 0x20 each
+channel_count = @0x10   # reads channels at 0x10+0x20*subsong
+# 1st subsong: 0x10+0x20*0: 0x10
+# 2nd subsong: 0x10+0x20*1: 0x30
+# 2nd subsong: 0x10+0x20*2: 0x50
+# ...
+start_offset = @0x14    # reads offset within data at 0x14+0x20*subsong
+
+subsong_offset = 0      # reset value
+sample_rate = 0x04      # sample rate is the same for all subsongs
+# Nth subsong ch: 0x04+0x00*N: 0x08
+```
+
+### Multipliers
+Sometimes header values are in "sectors" or similar concepts (typical in DVD games), and need to be adjusted to a real value.
+```
+value_multiplier = 0x800    # offsets are in DVD sector size
+start_offset = @0x10        # 2*0x800, for example
+value_multiplier = 0        # next values don't need to be multiplied
+start_offset = @0x14
 ```

--- a/src/formats.c
+++ b/src/formats.c
@@ -392,6 +392,7 @@ static const char* extension_list[] = {
     "trj",
     "trm",
     "tun",
+    "txth",
     "txtp",
     "tydsp",
 

--- a/src/meta/txtp.c
+++ b/src/meta/txtp.c
@@ -365,20 +365,9 @@ static int add_filename(txtp_header * txtp, char *filename) {
     }
 
 
-    /* hack to allow relative paths in various OSs */
-    {
-        char c;
+    fix_dir_separators(filename); /* clean paths */
 
-        i = 0;
-        while ((c = filename[i]) != '\0') {
-            if ((c == '\\' && DIR_SEPARATOR == '/') || (c == '/' && DIR_SEPARATOR == '\\'))
-                filename[i] = DIR_SEPARATOR;
-            i++;
-        }
-    }
-
-
-    /* add filesnames */
+    /* add filenames */
     for (i = range_start; i < range_end; i++){
         txtp_entry *current;
 

--- a/src/streamfile.c
+++ b/src/streamfile.c
@@ -955,6 +955,17 @@ fail:
     return 0;
 }
 
+/* hack to allow relative paths in various OSs */
+void fix_dir_separators(char * filename) {
+    char c;
+    int i = 0;
+    while ((c = filename[i]) != '\0') {
+        if ((c == '\\' && DIR_SEPARATOR == '/') || (c == '/' && DIR_SEPARATOR == '\\'))
+            filename[i] = DIR_SEPARATOR;
+        i++;
+    }
+}
+
 
 /**
  * Checks if the stream filename is one of the extensions (comma-separated, ex. "adx" or "adx,aix").

--- a/src/streamfile.h
+++ b/src/streamfile.h
@@ -206,6 +206,8 @@ size_t read_string(char * buf, size_t bufsize, off_t offset, STREAMFILE *streamF
 
 size_t read_key_file(uint8_t * buf, size_t bufsize, STREAMFILE *streamFile);
 
+void fix_dir_separators(char * filename);
+
 int check_extensions(STREAMFILE *streamFile, const char * cmp_exts);
 
 int find_chunk_be(STREAMFILE *streamFile, uint32_t chunk_id, off_t start_offset, int full_chunk_size, off_t *out_chunk_offset, size_t *out_chunk_size);


### PR DESCRIPTION
- Add TXTH dual file/bigfile/subsong/multiplier handling
  - Can loading a separate header_file or body_file for dual files
  - Can load from .txth directly while setting header_file/body_file for bigfiles
  - Can set value_multiplier for use with sector and similar values that must be multiplied
  - Can set subsong_count and subsong_offset for subsong headers suboffset
