### PR TITLE
pcfx etc

### DIFF
--- a/doc/TXTH.md
+++ b/doc/TXTH.md
@@ -190,11 +190,23 @@ body_file = (filename)|*.(extension)|null
 
 # Subsongs [OPTIONAL]
 # Sets the number of subsongs in the file, adjusting reads per subsong N:
-# "value = @(offset) + subsong_offset*N". Mainly for bigfiles with consecutive
-# headers per subsong, set subsong_offset to 0 when done as it affects any reads.
+# "value = @(offset) + subsong_offset*N". (number) values aren't adjusted
+# as they are seen as constants.
+# Mainly for bigfiles with consecutive headers per subsong, set subsong_offset
+# to 0 when done as it affects any reads.
 # The current subsong number is handled externally by plugins or TXTP.
 subsong_count = (number)|(offset)|(field)
 subsong_offset = (number)|(offset)|(field)
+
+# Names [OPTIONAL]
+# Sets the name of the stream, most useful when used with subsongs.
+# TXTH will read a string at name_offset, with name_size characters.
+# name_size defaults to 0, which reads until null-terminator or a
+# non-ascii character.
+# name_offset can be a (number) value, but being an offset it's also
+# adjusted by subsong_offset.
+name_offset = (number)|(offset)|(field)
+name_size = (number)|(offset)|(field)
 ```
 
 ## Usages

--- a/doc/TXTH.md
+++ b/doc/TXTH.md
@@ -79,6 +79,7 @@ A text file with the above commands must be saved as ".vag.txth" or ".txth", not
 # - XMA2           Microsoft XMA2
 # - FFMPEG         Any headered FFmpeg format
 # - AC3            AC3/SPDIF
+# - PCFX           PC-FX ADPCM
 codec = (codec string)
 
 # Codec variations [OPTIONAL, depends on codec]
@@ -86,6 +87,7 @@ codec = (codec string)
 # - ATRAC3: 0=autodetect joint stereo, 1=force joint stereo, 2=force normal stereo
 # - XMA1|XMA2: 0=dual multichannel (2ch xN), 1=single multichannel (1ch xN)
 # - XBOX: 0=standard (mono or stereo interleave), 1=force mono interleave mode
+# - PCFX: 0=standard, 1='buggy encoder' mode, 2/3=same as 0/1 but with double volume
 # - others: ignored
 codec_mode = (number)
 

--- a/doc/TXTP.md
+++ b/doc/TXTP.md
@@ -65,7 +65,7 @@ music_Home.ps3.scd#c3,4
 
 ### Multilayered songs
 
-TXTP "layers" play songs with channels/parts divided into files as one
+TXTP "layers" play songs with channels/parts divided into files as one.
 
 - __Nier Automata__: _BGM_0_012_song2.txtp_
 ```
@@ -85,6 +85,8 @@ BIK_E1_6A_DialEnd_00000000.audio.multi.bik#3
 
 mode = layers
 ```
+Note that the number of channels is the sum of all layers, so three 2ch layers play as a 6ch file.
+
 
 
 ### Channel swapping/mapping

--- a/src/coding/coding.h
+++ b/src/coding/coding.h
@@ -168,6 +168,10 @@ void decode_derf(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing,
 /* circus_decoder */
 void decode_circus_adpcm(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do);
 
+/* pcfx_decoder */
+void decode_pcfx(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int mode);
+size_t pcfx_bytes_to_samples(size_t bytes, int channels);
+
 /* ea_mt_decoder*/
 ea_mt_codec_data *init_ea_mt(int channels, int type);
 ea_mt_codec_data *init_ea_mt_loops(int channels, int pcm_blocks, int loop_sample, off_t *loop_offsets);

--- a/src/coding/pcfx_decoder.c
+++ b/src/coding/pcfx_decoder.c
@@ -1,0 +1,92 @@
+#include "coding.h"
+
+
+static const int step_sizes[49] = { /* OKI table */
+        16, 17, 19, 21, 23, 25, 28, 31, 34, 37, 41, 45, 50,
+        55, 60, 66, 73, 80, 88, 97, 107, 118, 130, 143, 157,
+        173, 190,  209, 230, 253, 279, 307, 337, 371, 408, 449,
+        494, 544, 598, 658, 724, 796, 876, 963, 1060, 1166, 1282, 1411, 1552
+};
+
+static const int stex_indexes[16] = { /* IMA table */
+        -1, -1, -1, -1, 2, 4, 6, 8,
+        -1, -1, -1, -1, 2, 4, 6, 8
+};
+
+
+static void pcfx_expand_nibble(VGMSTREAMCHANNEL * stream, off_t byte_offset, int nibble_shift, int32_t * hist1, int32_t * step_index, int16_t *out_sample, int mode) {
+    int code, step, delta;
+
+    code = (read_8bit(byte_offset,stream->streamfile) >> nibble_shift) & 0xf;
+    step = step_sizes[*step_index];
+
+    delta = (code & 0x7);
+    if (mode & 1) {
+        if (step == 1552) /* bad last step_sizes value from OKI table */
+            step = 1522;
+        delta = step * (delta + 1) * 2;
+    }
+    else {
+        delta = step * (delta + 1);
+    }
+    if (code & 0x8)
+        delta = -delta;
+
+    *step_index += stex_indexes[code];
+    if (*step_index < 0) *step_index = 0;
+    if (*step_index > 48) *step_index = 48;
+
+    *hist1 += delta;
+    if (*hist1 > 16383) *hist1 = 16383;
+    if (*hist1 < -16384) *hist1 = -16384;
+
+    if (mode & 1) {
+        *out_sample = *hist1;
+    } else {
+        *out_sample = *hist1 << 1;
+    }
+
+    /* seems real HW does filtering here too */
+
+    /* double volume since it clips at half */
+    if (mode & 2) {
+        *out_sample = *hist1 << 1;
+    }
+}
+
+
+/* PC-FX ADPCM decoding, variation of OKI/Dialogic/VOX ADPCM. Based on mednafen/pcfx-music-dump.
+ * Apparently most ADPCM was made with a buggy encoder, resulting in incorrect sound in real hardware
+ * and sound clipped at half. Decoding can be controlled with modes:
+ * - 0: hardware decoding (waveforms in many games will look wrong, ex. Der Langrisser track 032)
+ * - 1: 'buggy encoder' decoding (waveforms will look fine)
+ * - 2: hardware decoding with double volume (may clip?)
+ * - 3: 'buggy encoder' decoding with double volume
+ *
+ * PC-FX ISOs don't have a standard filesystem nor file formats (raw data must be custom-ripped),
+ * so it's needs GENH/TXTH. Sample rate can only be base_value divided by 1/2/3/4, where
+ * base_value is approximately ~31468.5 (follows hardware clocks), mono or stereo-interleaved.
+ */
+void decode_pcfx(VGMSTREAMCHANNEL * stream, sample * outbuf, int channelspacing, int32_t first_sample, int32_t samples_to_do, int mode) {
+    int i, sample_count = 0;
+    int32_t hist1 = stream->adpcm_history1_32;
+    int step_index = stream->adpcm_step_index;
+    int16_t out_sample;
+
+    for (i = first_sample; i < first_sample + samples_to_do; i++) {
+        off_t byte_offset = stream->offset + i/2;
+        int nibble_shift = (i&1?4:0); /* low nibble first */
+
+        pcfx_expand_nibble(stream, byte_offset,nibble_shift, &hist1, &step_index, &out_sample, mode);
+        outbuf[sample_count] = out_sample;
+        sample_count += channelspacing;
+    }
+
+    stream->adpcm_history1_32 = hist1;
+    stream->adpcm_step_index = step_index;
+}
+
+size_t pcfx_bytes_to_samples(size_t bytes, int channels) {
+    /* 2 samples per byte (2 nibbles) in stereo or mono config */
+    return bytes * 2 / channels;
+}

--- a/src/formats.c
+++ b/src/formats.c
@@ -616,6 +616,7 @@ static const coding_info coding_info_list[] = {
         {coding_FADPCM,             "FMOD FADPCM 4-bit ADPCM"},
         {coding_ASF,                "Argonaut ASF 4-bit ADPCM"},
         {coding_XMD,                "Konami XMD 4-bit ADPCM"},
+        {coding_PCFX,               "PC-FX 4-bit ADPCM"},
 
         {coding_SDX2,               "Squareroot-delta-exact (SDX2) 8-bit DPCM"},
         {coding_SDX2_int,           "Squareroot-delta-exact (SDX2) 8-bit DPCM with 1 byte interleave"},

--- a/src/formats.c
+++ b/src/formats.c
@@ -108,6 +108,7 @@ static const char* extension_list[] = {
     "cks",
     "cnk",
     "cps",
+    "csa", //txth/reserved [LEGO Racers 2 (PS2)]
     "csmp",
     "cvs",
     "cxs",

--- a/src/layout/blocked_ea_schl.c
+++ b/src/layout/blocked_ea_schl.c
@@ -33,10 +33,15 @@ void block_update_ea_schl(off_t block_offset, VGMSTREAM * vgmstream) {
             case 0x5344454E: /* "SDEN" */
             case 0x53444652: /* "SDFR" */
             case 0x53444745: /* "SDGE" */
+            case 0x53444445: /* "SDDE" */
             case 0x53444954: /* "SDIT" */
             case 0x53445350: /* "SDSP" */
+            case 0x53444553: /* "SDES" */
+            case 0x53444D58: /* "SDMX" */
             case 0x53445255: /* "SDRU" */
             case 0x53444A41: /* "SDJA" */
+            case 0x53444A50: /* "SDJP" */
+            case 0x5344504C: /* "SDPL" */
                 /* audio chunk */
                 if (vgmstream->coding_type == coding_PSX)
                     block_samples = ps_bytes_to_samples(block_size-0x10, vgmstream->channels);

--- a/src/libvgmstream.vcproj
+++ b/src/libvgmstream.vcproj
@@ -1890,6 +1890,10 @@
                     RelativePath=".\coding\ogg_vorbis_decoder.c"
                     >
                 </File>
+                <File
+                    RelativePath=".\coding\pcfx_decoder.c"
+                    >
+                </File>
 				<File
 					RelativePath=".\coding\pcm_decoder.c"
 					>

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -525,6 +525,7 @@
     <ClCompile Include="coding\ngc_dtk_decoder.c" />
     <ClCompile Include="coding\nwa_decoder.c" />
     <ClCompile Include="coding\ogg_vorbis_decoder.c" />
+    <ClCompile Include="coding\pcfx_decoder.c" />
     <ClCompile Include="coding\pcm_decoder.c" />
     <ClCompile Include="coding\psv_decoder.c" />
     <ClCompile Include="coding\psx_decoder.c" />

--- a/src/libvgmstream.vcxproj.filters
+++ b/src/libvgmstream.vcxproj.filters
@@ -1120,6 +1120,9 @@
     <ClCompile Include="coding\ogg_vorbis_decoder.c">
       <Filter>coding\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="coding\pcfx_decoder.c">
+      <Filter>coding\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="coding\pcm_decoder.c">
       <Filter>coding\Source Files</Filter>
     </ClCompile>

--- a/src/meta/ea_schl.c
+++ b/src/meta/ea_schl.c
@@ -62,13 +62,18 @@
 #define EA_BLOCKID_LOC_DATA     0x53440000 /* "SD" */
 #define EA_BLOCKID_LOC_END      0x53450000 /* "SE" */
 
-#define EA_BLOCKID_LOC_EN       0x0000454E
-#define EA_BLOCKID_LOC_FR       0x00004652
-#define EA_BLOCKID_LOC_GE       0x00004745
-#define EA_BLOCKID_LOC_IT       0x00004954
-#define EA_BLOCKID_LOC_SP       0x00005350
-#define EA_BLOCKID_LOC_RU       0x00005255
-#define EA_BLOCKID_LOC_JA       0x00004A41
+#define EA_BLOCKID_LOC_EN       0x0000454E /* English */
+#define EA_BLOCKID_LOC_FR       0x00004652 /* French */
+#define EA_BLOCKID_LOC_GE       0x00004745 /* German, older */
+#define EA_BLOCKID_LOC_DE       0x00004445 /* German, newer */
+#define EA_BLOCKID_LOC_IT       0x00004954 /* Italian */
+#define EA_BLOCKID_LOC_SP       0x00005350 /* Castilian Spanish, older */
+#define EA_BLOCKID_LOC_ES       0x00004553 /* Castilian Spanish, newer */
+#define EA_BLOCKID_LOC_MX       0x00004D58 /* Mexican Spanish */
+#define EA_BLOCKID_LOC_RU       0x00005255 /* Russian */
+#define EA_BLOCKID_LOC_JA       0x00004A41 /* Japanese, older */
+#define EA_BLOCKID_LOC_JP       0x00004A50 /* Japanese, newer */
+#define EA_BLOCKID_LOC_PL       0x0000504C /* Polish */
 
 #define EA_BNK_HEADER_LE        0x424E4B6C /* "BNKl" */
 #define EA_BNK_HEADER_BE        0x424E4B62 /* "BNKb" */
@@ -117,14 +122,19 @@ VGMSTREAM * init_vgmstream_ea_schl(STREAMFILE *streamFile) {
         read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_EN) &&  /* "SHEN" */
         read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_FR) &&  /* "SHFR" */
         read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_GE) &&  /* "SHGE" */
+        read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_DE) &&  /* "SHDE" */
         read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_IT) &&  /* "SHIT" */
         read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_SP) &&  /* "SHSP" */
+        read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_ES) &&  /* "SHES" */
+        read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_MX) &&  /* "SHMX" */
         read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_RU) &&  /* "SHRU" */
-        read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_JA))    /* "SHJA" */
+        read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_JA) &&  /* "SHJA" */
+        read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_JP) &&  /* "SHJP" */
+        read_32bitBE(0x00,streamFile) != (EA_BLOCKID_LOC_HEADER | EA_BLOCKID_LOC_PL))    /* "SHPL" */
         goto fail;
 
     /* Stream is divided into blocks/chunks: SCHl=audio header, SCCl=count of SCDl, SCDl=data xN, SCLl=loop end, SCEl=end.
-     * Video uses picture blocks (MVhd/MV0K/etc) and sometimes multiaudio blocks (SHxx/SCxx/SDxx/SExx where xx=language=EN/FR/GE/IT/SP/RU/JA).
+     * Video uses picture blocks (MVhd/MV0K/etc) and sometimes multiaudio blocks (SHxx/SCxx/SDxx/SExx where xx=language).
      * The number/size is affected by: block rate setting, sample rate, channels, CPU location (SPU/main/DSP/others), etc */
     return parse_schl_block(streamFile, 0x00, 0);
 
@@ -1243,10 +1253,15 @@ static off_t get_ea_stream_mpeg_start_offset(STREAMFILE* streamFile, off_t start
             case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_EN: /* "SDEN" */
             case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_FR: /* "SDFR" */
             case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_GE: /* "SDGE" */
+            case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_DE: /* "SDDE" */
             case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_IT: /* "SDIT" */
             case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_SP: /* "SDSP" */
+            case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_ES: /* "SDES" */
+            case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_MX: /* "SDMX" */
             case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_RU: /* "SDRU" */
             case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_JA: /* "SDJA" */
+            case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_JP: /* "SDJP" */
+            case EA_BLOCKID_LOC_DATA | EA_BLOCKID_LOC_PL: /* "SDPL" */
                 offset = read_32bit(block_offset+0x0c,streamFile); /* first value seems ok, second is something else in EALayer3 */
                 return block_offset + 0x0c + ea->channels*0x04 + offset;
             case 0x00000000:

--- a/src/meta/genh.c
+++ b/src/meta/genh.c
@@ -4,7 +4,6 @@
 #include "../util.h"
 
 
-
 /* known GENH types */
 typedef enum {
     PSX = 0,          /* PSX ADPCM */
@@ -31,6 +30,7 @@ typedef enum {
     XMA2 = 21,        /* raw XMA2 */
     FFMPEG = 22,      /* any headered FFmpeg format */
     AC3 = 23,         /* AC3/SPDIF */
+    PCFX = 24,        /* PC-FX ADPCM */
 } genh_type;
 
 typedef struct {
@@ -113,6 +113,7 @@ VGMSTREAM * init_vgmstream_genh(STREAMFILE *streamFile) {
         case AC3:
         case FFMPEG:     coding = coding_FFmpeg; break;
 #endif
+        case PCFX:       coding = coding_PCFX; break;
         default:
             goto fail;
     }
@@ -185,6 +186,14 @@ VGMSTREAM * init_vgmstream_genh(STREAMFILE *streamFile) {
             }
 
             break;
+
+        case coding_PCFX:
+            vgmstream->interleave_block_size = genh.interleave;
+            vgmstream->layout_type = layout_interleave;
+            if (genh.codec_mode >= 0 && genh.codec_mode <= 3)
+                vgmstream->codec_config = genh.codec_mode;
+            break;
+
         case coding_MS_IMA:
             if (!genh.interleave) goto fail; /* creates garbage */
 

--- a/src/meta/imc.c
+++ b/src/meta/imc.c
@@ -22,14 +22,12 @@ VGMSTREAM * init_vgmstream_imc(STREAMFILE *streamFile) {
     file_size = get_streamfile_size(streamFile);
     loop_flag  = 0;
     start_offset = 0x10;
-VGM_LOG("3\n");
+
     /* extra checks since the header is so simple */
     if (channel_count < 1 || channel_count > 8 || sample_rate < 22000 || sample_rate > 48000)
         goto fail;
-VGM_LOG("4\n");
     if (interleave*blocks + start_offset != file_size)
         goto fail;
-VGM_LOG("5\n");
 
     /* remove padding (important to play gapless subsongs, happens even for mono) */
     {
@@ -72,10 +70,9 @@ VGMSTREAM * init_vgmstream_imc_container(STREAMFILE *streamFile) {
     VGMSTREAM *vgmstream = NULL;
     STREAMFILE *temp_streamFile = NULL;
     off_t header_offset, subfile_offset, next_offset, name_offset;
-    uint32_t flags1, flags2;
-
     size_t subfile_size;
     int total_subsongs, target_subsong = streamFile->stream_index;
+
 
     /* checks */
     if (!check_extensions(streamFile, "imc"))
@@ -89,18 +86,12 @@ VGMSTREAM * init_vgmstream_imc_container(STREAMFILE *streamFile) {
     header_offset = 0x04 + 0x20*(target_subsong-1);
 
     name_offset = header_offset + 0x00;
-    //flags1 = (uint32_t)read_32bitLE(header_offset + 0x08, streamFile);
+    /* 0x08: flags? (0x702ADE77|0x002ADE77|0x20000000|etc) */
     /* 0x0c: same for all songs in single .imc but varies between .imc */
     subfile_offset = read_32bitLE(header_offset + 0x10,streamFile);
-    //flags2 = (uint32_t)read_32bitLE(header_offset + 0x14, streamFile);
+    /* 0x14: flags/size? (0xF0950000|0x3CFA1200|etc) */
     /* 0x18: same for all songs in single .imc but varies between .imc */
     /* 0x1c: flags? (0 or 2) */
-//VGM_LOG("1: %x, %x\n", flags1, flags2);
-//    if (!(flags1 == 0x77DE2A70 || flags1 == 0x77DE2A00 || flags1 == 0x00000020 || flags1 == 0x00000000))
-//        goto fail;
-//    if (!(flags2 == 0x0000F095 || flags2 == 0x0012FA3C))
-//        goto fail;
-//VGM_LOG("2\n");
 
     if (target_subsong == total_subsongs) {
         next_offset = get_streamfile_size(streamFile);

--- a/src/vgmstream.c
+++ b/src/vgmstream.c
@@ -1148,6 +1148,7 @@ int get_vgmstream_samples_per_frame(VGMSTREAM * vgmstream) {
         case coding_WV6_IMA:
         case coding_ALP_IMA:
         case coding_FFTA2_IMA:
+        case coding_PCFX:
             return 2;
         case coding_XBOX_IMA:
         case coding_XBOX_IMA_mch:
@@ -1320,6 +1321,7 @@ int get_vgmstream_frame_size(VGMSTREAM * vgmstream) {
         case coding_WV6_IMA:
         case coding_ALP_IMA:
         case coding_FFTA2_IMA:
+        case coding_PCFX:
             return 0x01;
         case coding_MS_IMA:
         case coding_RAD_IMA:
@@ -2019,6 +2021,13 @@ void decode_vgmstream(VGMSTREAM * vgmstream, int samples_written, int samples_to
                         vgmstream->interleave_block_size);
             }
             break;
+        case coding_PCFX:
+            for (ch = 0; ch < vgmstream->channels; ch++) {
+                decode_pcfx(&vgmstream->ch[ch],buffer+samples_written*vgmstream->channels+ch,
+                        vgmstream->channels,vgmstream->samples_into_block,samples_to_do, vgmstream->codec_config);
+            }
+            break;
+
         case coding_EA_MT:
             for (ch = 0; ch < vgmstream->channels; ch++) {
                 decode_ea_mt(vgmstream, buffer+samples_written*vgmstream->channels+ch,

--- a/src/vgmstream.h
+++ b/src/vgmstream.h
@@ -149,6 +149,7 @@ typedef enum {
     coding_FADPCM,          /* FMOD FADPCM 4-bit ADPCM */
     coding_ASF,             /* Argonaut ASF 4-bit ADPCM */
     coding_XMD,             /* Konami XMD 4-bit ADPCM */
+    coding_PCFX,            /* PC-FX 4-bit ADPCM */
 
     /* others */
     coding_SDX2,            /* SDX2 2:1 Squareroot-Delta-Exact compression DPCM */


### PR DESCRIPTION
- Fix some SCHl multilanguage videos [MOH Warfighter, NFS The Run]
- Add PCFX for GENH/TXTH [Der Langrisser FX (PC-FX)]
- Add name_offset/name_size option for TXTH
- Add .csa extension [LEGO Racers 2 (PS2)]
- Fix AWC MPEG not seeking back correctly